### PR TITLE
Invoke CodeMirror later on certain pages

### DIFF
--- a/documentation/templates/documentation/block.html
+++ b/documentation/templates/documentation/block.html
@@ -94,7 +94,7 @@
 <script src="{% static "codemirror/mode/javascript/javascript.js" %}"></script>
 <script src="{% static "codemirror/mode/htmlmixed/htmlmixed.js" %}"></script>
 <script type="text/javascript">
-$(function() {
+$(window).on("load", function() {
   $('pre').each(function() {
 
         var $this = $(this);

--- a/documentation/templates/documentation/embed.html
+++ b/documentation/templates/documentation/embed.html
@@ -39,7 +39,7 @@
 <script src="{% static "codemirror/mode/javascript/javascript.js" %}"></script>
 <script src="{% static "codemirror/mode/htmlmixed/htmlmixed.js" %}"></script>
 <script type="text/javascript">
-$(function() {
+$(window).on("load", function() {
   $('pre').each(function() {
 
         var $this = $(this);

--- a/documentation/templates/documentation/map.html
+++ b/documentation/templates/documentation/map.html
@@ -79,7 +79,7 @@
 <script src="{% static "codemirror/mode/javascript/javascript.js" %}"></script>
 <script src="{% static "codemirror/mode/htmlmixed/htmlmixed.js" %}"></script>
 <script type="text/javascript">
-$(function() {
+$(window).on("load", function() {
   $('pre').each(function() {
 
         var $this = $(this);

--- a/static/cdo/js/applab-docs.js
+++ b/static/cdo/js/applab-docs.js
@@ -1,5 +1,5 @@
 /*global CodeMirror*/
-$(function() {
+$(window).on("load", function() {
   $('pre').each(function() {
     var preElement = $(this);
     var code = dedent(preElement.text()).trim();


### PR DESCRIPTION
[LP-287](https://codedotorg.atlassian.net/browse/LP-287): We're seeing an issue where CodeMirror is applying incorrect spacing to HTML snippets only when the page is rendered within an iframe on a Code Studio map level.  This seems to be due to a timing issue - the CodeMirror handler is being invoked before the document in the iframe has fully loaded, leading to some incorrect calculations.

| [Embedded](https://studio.code.org/s/csd2-2018/stage/6/puzzle/6) | [Not Embedded](https://studio.code.org/docs/concepts/html/lists/index.html) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1615761/65471506-2e63eb80-de24-11e9-9551-25c238ea045a.png) | ![image](https://user-images.githubusercontent.com/1615761/65471516-3a4fad80-de24-11e9-894a-64774416c521.png) |


Here I'm suggesting we use jQuery's `$(window).on("load", fn)` instead of `$(fn)` / `$(document).ready(fn)` which explicitly waits for the whole page (including iframes) to be ready, not just the DOM.

Read more: https://learn.jquery.com/using-jquery-core/document-ready/

I'm not sure of the quickest way to verify this change.  Recommendations please?