### PR TITLE
remove unused lesson_pdf routes

### DIFF
--- a/curricula/urls.py
+++ b/curricula/urls.py
@@ -74,8 +74,6 @@ urlpatterns = patterns('curricula.views',
                        # Lesson URLs
                        url(r'^(?P<slug>[-\w]+)/(?P<unit_slug>[-\w]+)/(?P<lesson_num>\d+)/$',
                            views.lesson_view, name='lesson_view'),
-                       url(r'^(?P<slug>[-\w]+)/(?P<unit_slug>[-\w]+)/(?P<lesson_num>\d+)/pdf/$',
-                           views.lesson_pdf, name='lesson_pdf'),
                        url(r'^(?P<slug>[-\w]+)/(?P<unit_slug>[-\w]+)/(?P<lesson_num>\d+)/md/$',
                            views.lesson_markdown, name='lesson_markdown'),
                        url(r'^(?P<slug>[-\w]+)/(?P<unit_slug>[-\w]+)/(?P<lesson_num>\d+)/overview/$',


### PR DESCRIPTION
This route appears to be unused because (1) @mrjoshida says it is, but also because (2) there are no references to it either via urls ending in `/pdf/` or `/pdf`, or via url helpers like this one which points to a different route: https://github.com/mrjoshida/curriculumbuilder/blob/08ae80dfed1f9b66f95f16d8d1925fc28443e472/curricula/models.py#L82-L84
