### PR TITLE
Display properties differently for blockly based tools

### DIFF
--- a/documentation/templates/documentation/partials/block.html
+++ b/documentation/templates/documentation/partials/block.html
@@ -105,6 +105,27 @@
 {% endif %}
 
 {% if code_block.parameters.count > 0 %}
+    {% if code_block.parent_ide.language == 'blockly' %}
+    <div class="parameters">
+        <h2>Parameters</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Name</th><th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for parameter in code_block.parameters.all %}
+                <tr>
+                    <td>{{ parameter.name }}</td>
+                    <td>{{ parameter.description }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    {% else %}
     <div class="parameters">
         <h2>Parameters</h2>
         <table>
@@ -125,6 +146,7 @@
             </tbody>
         </table>
     </div>
+    {% endif %}
 {% endif %}
 
 {% if code_block.return_value %}

--- a/documentation/templates/documentation/partials/block.html
+++ b/documentation/templates/documentation/partials/block.html
@@ -106,46 +106,46 @@
 
 {% if code_block.parameters.count > 0 %}
     {% if code_block.parent_ide.language == 'blockly' %}
-    <div class="parameters">
-        <h2>Parameters</h2>
-        <table>
-            <thead>
-                <tr>
-                    <th>Name</th><th>Description</th>
-                </tr>
-            </thead>
-            <tbody>
-            {% for parameter in code_block.parameters.all %}
-                <tr>
-                    <td>{{ parameter.name }}</td>
-                    <td>{{ parameter.description }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    </div>
+        <div class="parameters">
+            <h2>Parameters</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th><th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for parameter in code_block.parameters.all %}
+                    <tr>
+                        <td>{{ parameter.name }}</td>
+                        <td>{{ parameter.description }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
 
     {% else %}
-    <div class="parameters">
-        <h2>Parameters</h2>
-        <table>
-            <thead>
-                <tr>
-                    <th>Name</th><th>Type</th><th>Required?</th><th>Description</th>
-                </tr>
-            </thead>
-            <tbody>
-            {% for parameter in code_block.parameters.all %}
-                <tr>
-                    <td>{{ parameter.name }}</td>
-                    <td>{{ parameter.type }}</td>
-                    <td><span class="required_param_{{ parameter.required }}"></span></td>
-                    <td>{{ parameter.description }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    </div>
+        <div class="parameters">
+            <h2>Parameters</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th><th>Type</th><th>Required?</th><th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for parameter in code_block.parameters.all %}
+                    <tr>
+                        <td>{{ parameter.name }}</td>
+                        <td>{{ parameter.type }}</td>
+                        <td><span class="required_param_{{ parameter.required }}"></span></td>
+                        <td>{{ parameter.description }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
     {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Per request by @mikeharv this hides the type and required columns in the parameters table for blockly documentation (currently only Sprite Lab). See https://docs.google.com/document/d/1vIw33WKqzlDm3SXyFKRXraIRCiXtCQ1m7ylUQv7UIcA/edit#heading=h.ijnjwv3fic1e