### PR TITLE
upgrade pycurl to avoid openssl problems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ oauthlib==1.0.3
 pdfkit==0.5.0
 plotly==1.9.3
 psycopg2==2.7.4
-pycurl==7.43.0
+pycurl==7.43.0.3
 pyPdf==1.13
 pytz==2015.7
 #requests==2.7.0


### PR DESCRIPTION
# Description

Previously, installing pycurl on Mac OS resulted in an error which is documented here: https://github.com/code-dot-org/curriculumbuilder/commit/98ceaffc5568b3f03c116de515e72943be931912#diff-04c6e90faac2675aa89e2176d2eec7d8R83-R85

This does not appear to be a problem in the latest version of pycurl.

## Testing

Manually verified via the following steps:
```
pip uninstall pycurl
rm -rf ~/Library/Caches/pip # clear pip cache on Mac OS
rm -rf ~/.cache/pip # clear pip cache on Ubuntu
pip install -r requirements.txt
debug=true python manage.py runserver_plus
```
http://localhost:8000/ 