### PR TITLE
Add translation support for "Lesson N" headings

### DIFF
--- a/curricula/templates/curricula/chapter.html
+++ b/curricula/templates/curricula/chapter.html
@@ -97,7 +97,11 @@
                     {% if week.grouper != None %}<h2>Week {{ week.grouper }}</h2>{% endif %}
                     {% for lesson in week.list %}
                         <div class="lesson_overview">
-                            <h3><a href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">{% trans 'Lesson' %} {{ lesson.number }}: {{ lesson.title }}</a></h3>
+                            <h3>
+                              <a href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">
+                                {% blocktrans with lesson_number=lesson.number %}Lesson {{ lesson_number }}{% endblocktrans %}: {{ lesson.title }}
+                              </a>
+                            </h3>
                             <h4>
                             {% keywords_for lesson as keywords %}
                             {% for keyword in keywords %}

--- a/curricula/templates/curricula/unit.html
+++ b/curricula/templates/curricula/unit.html
@@ -4,6 +4,7 @@
 {% load static %}
 {% load mezzanine_tags %}
 {% load keyword_tags %}
+{% load i18n %}
 
 {% block meta_title %}{{ unit.curriculum }} | {{ unit.title }}{% endblock %}
 
@@ -114,7 +115,11 @@
                     {% for lesson in week.list %}
                         {% keywords_for lesson as keywords %}
                         <div class="lesson_overview {% for keyword in keywords %}{{ keyword|slugify }} {% endfor %}">
-                            <h3><a href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">Lesson {{ lesson.number }}: {{ lesson.title }}</a></h3>
+                            <h3>
+                              <a href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">
+                                {% blocktrans with lesson_number=lesson.number %}Lesson {{ lesson_number }}{% endblocktrans %}: {{ lesson.title }}
+                              </a>
+                            </h3>
                             <h4>
                             {% for keyword in keywords %}
                                 {% if not forloop.first %}| {% endif %}
@@ -201,7 +206,11 @@
                     {% if week.grouper != None %}<h2>Week {{ week.grouper }}</h2>{% endif %}
                     {% for lesson in week.list %}
                         <div class="lesson_overview {% for keyword in keywords %}{{ keyword|slugify }} {% endfor %}">
-                            <h3><a href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">Lesson {{ lesson.number }}: {{ lesson.title }}</a></h3>
+                            <h3>
+                              <a href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">
+                                {% blocktrans with lesson_number=lesson.number %}Lesson {{ lesson_number }}{% endblocktrans %}: {{ lesson.title }}
+                              </a>
+                            </h3>
                             <h4>
                             {% for keyword in lesson.translated_keywords %}
                                 {% if not forloop.first %}| {% endif %}

--- a/curricula/templates/curricula/unit_glance.html
+++ b/curricula/templates/curricula/unit_glance.html
@@ -4,6 +4,7 @@
 {% load static %}
 {% load mezzanine_tags %}
 {% load keyword_tags %}
+{% load i18n %}
 
 {% block meta_title %}{{ unit.curriculum }} | {{ unit.title }}{% endblock %}
 
@@ -86,7 +87,11 @@
                     {% for lesson in week.list %}
                         {% keywords_for lesson as keywords %}
                         <div class="lesson_overview {% for keyword in keywords %}{{ keyword|slugify }} {% endfor %}">
-                            <h3><a href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">Lesson {{ lesson.number }}: {{ lesson.title }}</a></h3>
+                            <h3>
+                              <a href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">
+                                {% blocktrans with lesson_number=lesson.number %}Lesson {{ lesson_number }}{% endblocktrans %}: {{ lesson.title }}
+                              </a>
+                            </h3>
                             <h4>
                             {% for keyword in keywords %}
                                 {% if not forloop.first %}| {% endif %}
@@ -128,7 +133,11 @@
                     {% for lesson in week.list %}
                         {% keywords_for lesson as keywords %}
                         <div class="lesson_overview {% for keyword in keywords %}{{ keyword|slugify }} {% endfor %}">
-                            <h3><a href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">Lesson {{ lesson.number }}: {{ lesson.title }}</a></h3>
+                            <h3>
+                              <a href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">
+                                {% blocktrans with lesson_number=lesson.number %}Lesson {{ lesson_number }}{% endblocktrans %}: {{ lesson.title }}
+                              </a>
+                            </h3>
                             <h4>
                             {% for keyword in keywords %}
                                 {% if not forloop.first %}| {% endif %}

--- a/curricula/templates/curricula/unit_lessons.html
+++ b/curricula/templates/curricula/unit_lessons.html
@@ -4,6 +4,7 @@
 {% load static %}
 {% load mezzanine_tags %}
 {% load keyword_tags %}
+{% load i18n %}
 
 {% block meta_title %}{{ unit.curriculum }} | {{ unit.title }}{% endblock %}
 
@@ -75,7 +76,9 @@
                             <div class="lesson_overview
                                     {% for keyword in keywords %}{{ keyword|slugify }} {% endfor %}">
                                 <h3>
-                                    <a href="#U{{ unit.number }}L{{ lesson.number }}">Lesson {{ lesson.number }}: {{ lesson.title }}</a>
+                                    <a href="#U{{ unit.number }}L{{ lesson.number }}">
+                                      {% blocktrans with lesson_number=lesson.number %}Lesson {{ lesson_number }}{% endblocktrans %}: {{ lesson.title }}
+                                    </a>
                                 </h3>
                                 <h4>
                                     {% for keyword in keywords %}
@@ -126,7 +129,9 @@
                     <div class="lesson_overview
                             {% for keyword in keywords %}{{ keyword|slugify }} {% endfor %}">
                         <h3>
-                            <a href="#U{{ unit.number }}L{{ lesson.number }}">Lesson {{ lesson.number }}: {{ lesson.title }}</a>
+                            <a href="#U{{ unit.number }}L{{ lesson.number }}">
+                              {% blocktrans with lesson_number=lesson.number %}Lesson {{ lesson_number }}{% endblocktrans %}: {{ lesson.title }}
+                            </a>
                         </h3>
                         <h4>
                             {% for keyword in keywords %}


### PR DESCRIPTION
# Description
https://codedotorg.atlassian.net/browse/FND-679
The Lesson 1, Lesson 2, etc headers on the Curriculum Builder pages were not being translated (see JIRA for screenshot). I found the original reported String and a few other's which matched it and decided to add translations for them all.

# Testing
* Verified page still showed Lesson 1, Lesson 2, etc
`debug=true python manage.py runserver_plus`
* Found the following entry in `i18n/static/source/django.po` after running `bin/sync-i18n.sh`
``` python
#: curricula/templates/curricula/chapter.html:102
#: curricula/templates/curricula/unit.html:120
#: curricula/templates/curricula/unit.html:211
#: curricula/templates/curricula/unit_glance.html:92
#: curricula/templates/curricula/unit_glance.html:138
#: curricula/templates/curricula/unit_lessons.html:81
#: curricula/templates/curricula/unit_lessons.html:134
#, python-format
msgid "Lesson %(lesson_number)s"
msgstr ""
```

# References
* `transblock` https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#internationalization-in-template-code