### PR TITLE
Log all errors from manage.py commands

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -741,6 +741,11 @@ LOGGING = {
             'handlers': ['console', 'mail_admins', 'slack_admins'],
             'level': 'DEBUG',
             'propagate': True
+        },
+        'management_commands': {
+            'handlers': ['console', 'slack_admins'],
+            'level': 'ERROR',
+            'propagate': True
         }
     },
 }

--- a/manage.py
+++ b/manage.py
@@ -10,5 +10,11 @@ if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)
 
     from django.core.management import execute_from_command_line
+    from django.utils.log import getLogger
 
-    execute_from_command_line(sys.argv)
+    try:
+        execute_from_command_line(sys.argv)
+    except Exception as e:
+        logger = getLogger('management_commands')
+        logger.error('Management Command Error: %s', ' '.join(sys.argv), exc_info=sys.exc_info())
+        raise e


### PR DESCRIPTION
Primarily so we can make sure to capture errors in the i18n sync, which is implemented as an automated series of manage.py commands. But also generally is just good practice.