### PR TITLE
Use queryset iterator to gather i18n strings

### DIFF
--- a/i18n/models.py
+++ b/i18n/models.py
@@ -52,7 +52,12 @@ class Internationalizable(models.Model):
         total = objects.count()
         index = 0
         elapsed = 0
-        for obj in objects.all():
+        # Because this process is intended to be invoked from a management
+        # command, we don't care about caching the results of the queryset. In
+        # fact, in the case of large querysets that cache can have significant
+        # performance implications, so here we use iterator() to skip the
+        # cache.
+        for obj in objects.all().iterator():
             index += 1
             average = elapsed / index
             expected = elapsed + ((total - index) * average)


### PR DESCRIPTION
So we don't crash when trying to gather strings for models that have a large number of iternationalizable objects.

See https://docs.djangoproject.com/en/1.8/ref/models/querysets/#iterator and https://blog.etianen.com/blog/2013/06/08/django-querysets/ for more information