### PR TITLE
improve i18n sync error messaging

### DIFF
--- a/bin/sync-i18n.sh
+++ b/bin/sync-i18n.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-set -e
-
-python manage.py gather_i18n_strings
-python manage.py i18n_sync_up
-python manage.py i18n_sync_down
-python manage.py publish_i18n
+# Try to run the four steps of the i18n sync in sequence and then log a success
+# message. If any of the four steps (or the process of logging the success
+# message) fail, log an error message.
+python manage.py gather_i18n_strings && \
+  python manage.py i18n_sync_up && \
+  python manage.py i18n_sync_down && \
+  python manage.py publish_i18n && \
+  python manage.py log_i18n_success || \
+  python manage.py log_i18n_failure

--- a/i18n/management/commands/log_i18n_failure.py
+++ b/i18n/management/commands/log_i18n_failure.py
@@ -9,4 +9,4 @@ class Command(BaseCommand):
     See bin/sync_i18n.sh for context.
     """
     def handle(self, *args, **options):
-        log("WARNING: I18n Sync encountered an error")
+        log("ERROR: I18n Sync encountered a problem and did not complete")

--- a/i18n/management/commands/log_i18n_failure.py
+++ b/i18n/management/commands/log_i18n_failure.py
@@ -1,0 +1,12 @@
+# pylint: disable=missing-docstring
+from i18n.management.utils import log
+
+from django.core.management.base import BaseCommand
+
+class Command(BaseCommand):
+    """
+    Used by the i18n sync to alert that not all steps finished successfully.
+    See bin/sync_i18n.sh for context.
+    """
+    def handle(self, *args, **options):
+        log("WARNING: I18n Sync encountered an error")

--- a/i18n/management/commands/log_i18n_success.py
+++ b/i18n/management/commands/log_i18n_success.py
@@ -1,0 +1,12 @@
+# pylint: disable=missing-docstring
+from i18n.management.utils import log
+
+from django.core.management.base import BaseCommand
+
+class Command(BaseCommand):
+    """
+    Used by the i18n sync to confirm that all steps finished successfully. See
+    bin/sync_i18n.sh for context.
+    """
+    def handle(self, *args, **options):
+        log("I18n Sync finished successfully!")


### PR DESCRIPTION
Previously, we just logged each step of the i18n sync individually, including an indication that all steps had finished. The problem with that is of course that if all steps _didn't_ finish, you have to be paying explicit attention to notice.

This adds a more explicit error message when anything goes wrong.