### PR TITLE
Vocab migrations

### DIFF
--- a/lessons/migrations/0044_auto_20191021_1519.py
+++ b/lessons/migrations/0044_auto_20191021_1519.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('generic', '0002_auto_20141227_0224'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('lessons', '0043_auto_20190520_1630'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='I18nKeyword',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('generic.keyword', models.Model),
+        ),
+        migrations.AddField(
+            model_name='vocab',
+            name='user',
+            field=models.ForeignKey(related_name='vocabs', default=1, verbose_name='Author', to=settings.AUTH_USER_MODEL),
+            preserve_default=False,
+        ),
+    ]

--- a/lessons/migrations/0045_auto_20191022_1419.py
+++ b/lessons/migrations/0045_auto_20191022_1419.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lessons', '0044_auto_20191021_1519'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='vocab',
+            options={'ordering': ['word'], 'verbose_name_plural': 'vocab words', 'permissions': [('access_all_vocab', 'Can access all vocab')]},
+        ),
+    ]

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -96,6 +96,7 @@ class Vocab(Internationalizable):
         ordering = ["word"]
         verbose_name_plural = "vocab words"
         unique_together = ('word', 'mathy')
+        permissions = [('access_all_vocab', 'Can access all vocab')]
 
     @property
     def i18n_key(self):

--- a/standards/migrations/0007_auto_20191021_1519.py
+++ b/standards/migrations/0007_auto_20191021_1519.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('standards', '0006_auto_20170929_1528'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='standard',
+            name='gradeband',
+            field=models.ForeignKey(related_name='standards', to='standards.GradeBand'),
+        ),
+    ]


### PR DESCRIPTION
migrations for https://github.com/code-dot-org/curriculumbuilder/pull/168 . See that PR for context.