### PR TITLE
add owner field and access_all permission to other models

### DIFF
--- a/curricula/migrations/0031_auto_20191023_1350.py
+++ b/curricula/migrations/0031_auto_20191023_1350.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('curricula', '0030_auto_20190508_1556'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='chapter',
+            options={'ordering': ('_order',), 'permissions': [('access_all_chapters', 'Can access all chapters')]},
+        ),
+        migrations.AlterModelOptions(
+            name='curriculum',
+            options={'ordering': ('_order',), 'verbose_name_plural': 'curricula', 'permissions': [('access_all_curricula', 'Can access all curricula')]},
+        ),
+        migrations.AlterModelOptions(
+            name='unit',
+            options={'ordering': ('_order',), 'permissions': [('access_all_units', 'Can access all units')]},
+        ),
+        migrations.AddField(
+            model_name='chapter',
+            name='user',
+            field=models.ForeignKey(related_name='chapters', default=1, verbose_name='Author', to=settings.AUTH_USER_MODEL),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='curriculum',
+            name='user',
+            field=models.ForeignKey(related_name='curriculums', default=1, verbose_name='Author', to=settings.AUTH_USER_MODEL),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='unit',
+            name='user',
+            field=models.ForeignKey(related_name='units', default=1, verbose_name='Author', to=settings.AUTH_USER_MODEL),
+            preserve_default=False,
+        ),
+    ]

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -21,6 +21,8 @@ from django_slack import slack_message
 
 from django_cloneable import CloneableMixin
 
+from mezzanine.core.models import Ownable
+
 from standards.models import Standard, GradeBand, Category, Framework
 from documentation.models import Map
 import lessons.models
@@ -35,7 +37,7 @@ Curriculum
 """
 
 
-class Curriculum(InternationalizablePage, RichText, CloneableMixin):
+class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
     CURRENT = 0
     NEXT = 1
     PAST = 2
@@ -63,6 +65,7 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin):
 
     class Meta:
         verbose_name_plural = "curricula"
+        permissions = [('access_all_curricula', 'Can access all curricula')]
 
     @classmethod
     def internationalizable_fields(cls):
@@ -262,7 +265,7 @@ Curricular Unit
 """
 
 
-class Unit(InternationalizablePage, RichText, CloneableMixin):
+class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
     curriculum = models.ForeignKey(Curriculum, blank=True, null=True)
     ancestor = models.ForeignKey('self', blank=True, null=True, on_delete=models.SET_NULL)
     disable_numbering = models.BooleanField(default=False, help_text="Override to disable unit numbering")
@@ -283,6 +286,9 @@ class Unit(InternationalizablePage, RichText, CloneableMixin):
                                                 help_text='Override default lesson template,'
                                                           'eg curricula/pl_lesson.html')
     i18n_ready = models.BooleanField(default=False, help_text="Ready for internationalization")
+
+    class Meta:
+        permissions = [('access_all_units', 'Can access all units')]
 
     @classmethod
     def internationalizable_fields(cls):
@@ -615,7 +621,7 @@ Unit Chapter
 """
 
 
-class Chapter(InternationalizablePage, RichText, CloneableMixin):
+class Chapter(InternationalizablePage, RichText, CloneableMixin, Ownable):
     ancestor = models.ForeignKey('self', blank=True, null=True, on_delete=models.SET_NULL)
     number = models.IntegerField('Number', blank=True, null=True)
     questions = RichTextField(blank=True, null=True, help_text="md list of big questions")
@@ -624,6 +630,7 @@ class Chapter(InternationalizablePage, RichText, CloneableMixin):
 
     class Meta:
         order_with_respect_to = "parent"
+        permissions = [('access_all_chapters','Can access all chapters')]
 
     @classmethod
     def internationalizable_fields(cls):

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -15,77 +15,80 @@ class CurriculaRenderingTestCase(TestCase):
         self.test_curriculum = Curriculum.objects.create(
             title="Test Curriculum",
             slug="test-curriculum",
-            assessment_commentary="Assessment Commentary")
+            assessment_commentary="Assessment Commentary",
+            user=user)
         self.csf_curriculum = Curriculum.objects.create(
             title="CSF Curriculum",
             slug="csf-curriculum",
             assessment_commentary="CSF Commentary",
-            unit_template_override='curricula/csf_unit.html')
+            unit_template_override='curricula/csf_unit.html',
+            user=user)
         self.pl_curriculum = Curriculum.objects.create(
             title="PL Curriculum",
             slug="pl-curriculum",
             assessment_commentary="PL Commentary",
-            unit_template_override='curricula/pl_unit.html')
+            unit_template_override='curricula/pl_unit.html',
+            user=user)
         self.test_unit = Unit.objects.create(
             title="Test Unit",
             parent=self.test_curriculum,
             slug="test-unit",
             description="Test unit description",
-            show_calendar=True
-        )
+            show_calendar=True,
+            user=user)
         self.hoc_unit = Unit.objects.create(
             title="HoC Unit",
             parent=self.test_curriculum,
             slug="hoc-unit",
             description="Hoc unit description",
-            lesson_template_override="curricula/hoc_lesson.html"
-        )
+            lesson_template_override="curricula/hoc_lesson.html",
+            user=user)
         self.csf_unit = Unit.objects.create(
             title="CSF Unit",
             parent=self.csf_curriculum,
             slug="csf-unit",
             description="CSF unit description",
-            lesson_template_override="curricula/csf_lesson.html"
-        )
+            lesson_template_override="curricula/csf_lesson.html",
+            user=user)
         self.pl_unit = Unit.objects.create(
             title="PL Unit",
             parent=self.pl_curriculum,
             slug="pl-unit",
             description="PL unit description",
-            lesson_template_override="curricula/pl_lesson.html"
-        )
+            lesson_template_override="curricula/pl_lesson.html",
+            user=user)
         resource = Resource.objects.create(
             name="Test Resource",
             slug="test-resource",
-            student=True
-        )
+            student=True,
+            user=user)
         self.test_lesson = Lesson.objects.create(
             title="Test Lesson",
             parent=self.test_unit,
             overview="Overview",
-            prep="Prep"
-        )
+            prep="Prep",
+            user=user)
         self.test_lesson.resources.add(resource)
         self.hoc_lesson = Lesson.objects.create(
             title="HoC Lesson",
             parent=self.hoc_unit,
             overview="HoC Overview",
-            prep="Prep"
-        )
+            prep="Prep",
+            user=user)
         self.hoc_lesson.resources.add(resource)
         self.csf_lesson = Lesson.objects.create(
             title="CSF Lesson",
             parent=self.csf_unit,
             overview="CSF Overview",
-            prep="Prep"
-        )
+            prep="Prep",
+            user=user)
         self.csf_lesson.resources.add(resource)
         self.pl_lesson = Lesson.objects.create(
             title="PL Lesson",
             parent=self.pl_unit,
             overview="PL Overview",
-            prep="Prep"
-        )
+            prep="Prep",
+            user=user)
         self.pl_lesson.resources.add(resource)
 
     def test_homepage(self):

--- a/lessons/migrations/0046_auto_20191023_1357.py
+++ b/lessons/migrations/0046_auto_20191023_1357.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('lessons', '0045_auto_20191022_1419'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='activity',
+            options={'ordering': ('_order',), 'verbose_name_plural': 'activities', 'permissions': [('access_all_activities', 'Can access all activities')]},
+        ),
+        migrations.AlterModelOptions(
+            name='lesson',
+            options={'ordering': ['number'], 'permissions': [('access_all_lessons', 'Can access all lessons')]},
+        ),
+        migrations.AlterModelOptions(
+            name='objective',
+            options={'ordering': ('_order',), 'permissions': [('access_all_objectives', 'Can access all objectives')]},
+        ),
+        migrations.AlterModelOptions(
+            name='resource',
+            options={'ordering': ['name'], 'permissions': [('access_all_resources', 'Can access all resources')]},
+        ),
+        migrations.AddField(
+            model_name='activity',
+            name='user',
+            field=models.ForeignKey(related_name='activitys', default=1, verbose_name='Author', to=settings.AUTH_USER_MODEL),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='lesson',
+            name='user',
+            field=models.ForeignKey(related_name='lessons', default=1, verbose_name='Author', to=settings.AUTH_USER_MODEL),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='objective',
+            name='user',
+            field=models.ForeignKey(related_name='objectives', default=1, verbose_name='Author', to=settings.AUTH_USER_MODEL),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='resource',
+            name='user',
+            field=models.ForeignKey(related_name='resources', default=1, verbose_name='Author', to=settings.AUTH_USER_MODEL),
+            preserve_default=False,
+        ),
+    ]

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -133,7 +133,7 @@ Linked Resources
 """
 
 
-class Resource(Orderable, Internationalizable):
+class Resource(Orderable, Internationalizable, Ownable):
     name = models.CharField(max_length=255)
     type = models.CharField(max_length=255, blank=True, null=True)
     student = models.BooleanField('Student Facing', default=False)
@@ -153,6 +153,7 @@ class Resource(Orderable, Internationalizable):
 
     class Meta:
         ordering = ['name', ]
+        permissions = [('access_all_resources','Can access all resources')]
 
     @property
     def i18n_key(self):
@@ -308,7 +309,7 @@ Complete Lesson Page
 """
 
 
-class Lesson(InternationalizablePage, RichText, CloneableMixin):
+class Lesson(InternationalizablePage, RichText, CloneableMixin, Ownable):
     overview = RichTextField('Lesson Overview')
     short_title = models.CharField('Short Title (optional)', help_text='Used where space is at a premium',
                                    max_length=64, blank=True, null=True)
@@ -346,6 +347,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin):
 
     class Meta:
         ordering = ["number"]
+        permissions = [('access_all_lessons', 'Can access all lessons')]
 
     @classmethod
     def get_i18n_objects(cls):
@@ -665,7 +667,7 @@ Activities that compose a lesson
 """
 
 
-class Activity(Orderable, CloneableMixin, Internationalizable):
+class Activity(Orderable, CloneableMixin, Internationalizable, Ownable):
     name = models.CharField(max_length=255)
     content = RichTextField('Activity Content')
     keywords = KeywordsField()
@@ -677,6 +679,7 @@ class Activity(Orderable, CloneableMixin, Internationalizable):
         verbose_name_plural = "activities"
         order_with_respect_to = "lesson"
         unique_together = ('lesson', 'name')
+        permissions = [('access_all_activities', 'Can access all activities')]
 
     @classmethod
     def internationalizable_fields(cls):
@@ -742,13 +745,14 @@ Learning Objectives
 """
 
 
-class Objective(Orderable, Internationalizable, CloneableMixin):
+class Objective(Orderable, Internationalizable, CloneableMixin, Ownable):
     name = models.CharField(max_length=255)
     description = models.TextField(blank=True, null=True)
     lesson = models.ForeignKey(Lesson)
 
     class Meta:
         order_with_respect_to = "lesson"
+        permissions = [('access_all_objectives','Can access all objectives')]
 
     @classmethod
     def get_i18n_objects(cls):

--- a/standards/tests.py
+++ b/standards/tests.py
@@ -7,6 +7,7 @@ import io
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
+from django.contrib.auth.models import User
 
 from curricula.models import Curriculum, Unit
 from lessons.models import Lesson
@@ -19,9 +20,11 @@ class StandardsViewsTestCase(TestCase):
         # simple test suite, but until we have some kind of test factory
         # library this is what we have to do.
         # TODO simplify this if we ever set up a test factory.
-        self.test_curriculum = Curriculum.objects.create(title="Test Curriculum")
-        self.test_unit = Unit.objects.create(title="Test Unit", parent=self.test_curriculum)
-        self.test_lesson = Lesson.objects.create(title="Test Lesson", parent=self.test_unit)
+        user = User.objects.create_user(username='user', password='12345')
+        user.save()
+        self.test_curriculum = Curriculum.objects.create(title="Test Curriculum", user=user)
+        self.test_unit = Unit.objects.create(title="Test Unit", parent=self.test_curriculum, user=user)
+        self.test_lesson = Lesson.objects.create(title="Test Lesson", parent=self.test_unit, user=user)
         self.test_framework = Framework.objects.create(
             name="Test Framework",
             slug="test_framework",


### PR DESCRIPTION
migrations for https://github.com/code-dot-org/curriculumbuilder/pull/172 . See that PR for context.