### PR TITLE
add linux-friendly database config to local settings example

### DIFF
--- a/curriculumBuilder/local_settings.py.example
+++ b/curriculumBuilder/local_settings.py.example
@@ -21,6 +21,6 @@ CACHES = {
 DATABASES = {
     "default": {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-	'NAME': 'curriculumbuilder',
+        'NAME': 'curriculumbuilder',
     }
 }

--- a/curriculumBuilder/local_settings.py.example
+++ b/curriculumBuilder/local_settings.py.example
@@ -17,3 +17,10 @@ CACHES = {
         'LOCATION': 'unique-snowflake',
     }
 }
+
+DATABASES = {
+    "default": {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+	'NAME': 'curriculumbuilder',
+    }
+}


### PR DESCRIPTION
these changes are needed in local_settings.py in order for Linux setup instructions to work, and adding them doesn't seem to break running the local server on Mac, so rather than adding another step to the setup it seems best to just include these in the local settings file which is already copied into place during existing setup steps.