### PR TITLE
fix lesson page inline editors

### DIFF
--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -84,7 +84,7 @@ class ActivityInline(StackedDynamicInlineAdmin):
 
     keywords = KeywordsField()
 
-    exclude = ['ancestor', ]
+    exclude = ['ancestor', 'user',]
 
 
 class ResourceInline(TabularDynamicInlineAdmin):

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -710,6 +710,11 @@ class Activity(Orderable, CloneableMixin, Internationalizable):
                 logger.debug('Activity order changing! Activity %s, lesson %s' % (self.pk, self.lesson.pk))
         except:
             pass
+
+        # Supply default value for user_id when an Activity is created
+        # via InlineModelAdmin on the Lesson admin page.
+        self.user_id = self.user_id or self.lesson.user_id
+
         super(Activity, self).save(*args, **kwargs)
 
 
@@ -768,6 +773,11 @@ class Objective(Orderable, Internationalizable, CloneableMixin):
     def save(self, *args, **kwargs):
         if not self.description:
             self.description = self.name
+
+        # Supply default value for user_id when an Objective is created
+        # via InlineModelAdmin on the Lesson admin page.
+        self.user_id = self.user_id or self.lesson.user_id
+
         super(Objective, self).save(*args, **kwargs)
 
 


### PR DESCRIPTION
Quick fix for two problems on the lesson edit page introduced in https://github.com/code-dot-org/curriculumbuilder/pull/173, namely that you can't add an objective or activity. see error here: 
![Screen Shot 2019-10-25 at 4 19 52 PM](https://user-images.githubusercontent.com/8001765/67609773-4f7d6c00-f743-11e9-989a-598984db1fa2.png)

The [InlineModelAdmin](https://docs.djangoproject.com/en/2.2/ref/contrib/admin/#django.contrib.admin.InlineModelAdmin) class used to insert the editors for objectives and activities into the lessons page doesn't have a great way to insert a default value for the user_id, so I couldn't easily copy the approach used by [OwnableAdmin](http://mezzanine.jupo.org/docs/_modules/mezzanine/core/admin.html#OwnableAdmin) . 