### PR TITLE
override Ownable and allow inline editing of lessons

### DIFF
--- a/lessons/models.py
+++ b/lessons/models.py
@@ -399,7 +399,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Ownable):
 
     # temporary fix to override Ownable and allow inline editing of lessons
     def is_editable(self, request):
-        return super(Ownable, self).is_editable(request)
+        return request.user.has_perm('lessons.change_lesson')
 
     '''
     def get_number(self):

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -397,6 +397,10 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Ownable):
                 return None
         return parent.unit
 
+    # temporary fix to override Ownable and allow inline editing of lessons
+    def is_editable(self, request):
+        return super(Ownable, self).is_editable(request)
+
     '''
     def get_number(self):
         order = 1


### PR DESCRIPTION
https://github.com/code-dot-org/curriculumbuilder/pull/173 broke curriculum team's ability to edit lesson plans inline. this is a temporary fix to unblock them.