### PR TITLE
extract and implement Filterable class in Ownable models

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -37,6 +37,7 @@ Curriculum
 """
 
 
+# TODO(dave): make this implement lessons.models.Filterable
 class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
     CURRENT = 0
     NEXT = 1
@@ -95,6 +96,9 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
         # they own it.
         if not request.user.has_perm('curricula.access_all_curricula'):
             raise PageMoveException('You do not have permission to move curriculum')
+
+    def is_editable(self, request):
+        return self.can_access(request) and request.user.has_perm('curricula.change_curriculum')
 
     def get_absolute_url(self):
         return reverse('curriculum:curriculum_view', args=[self.slug])
@@ -282,6 +286,7 @@ Curricular Unit
 """
 
 
+# TODO(dave): make this implement lessons.models.Filterable
 class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
     curriculum = models.ForeignKey(Curriculum, blank=True, null=True)
     ancestor = models.ForeignKey('self', blank=True, null=True, on_delete=models.SET_NULL)
@@ -344,6 +349,8 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
         if not Page.get_content_model(new_parent).can_access(request):
             raise PageMoveException('Cannot move a unit to a curriculum you do not own')
 
+    def is_editable(self, request):
+        return self.can_access(request) and request.user.has_perm('curricula.change_unit')
 
     def get_absolute_url(self):
         return reverse('curriculum:unit_view', args=[self.curriculum.slug, self.slug])
@@ -655,6 +662,7 @@ Unit Chapter
 """
 
 
+# TODO(dave): make this implement lessons.models.Filterable
 class Chapter(InternationalizablePage, RichText, CloneableMixin, Ownable):
     ancestor = models.ForeignKey('self', blank=True, null=True, on_delete=models.SET_NULL)
     number = models.IntegerField('Number', blank=True, null=True)
@@ -694,6 +702,9 @@ class Chapter(InternationalizablePage, RichText, CloneableMixin, Ownable):
             raise PageMoveException('Cannot move a chapter you do not own')
         if not Page.get_content_model(new_parent).can_access(request):
             raise PageMoveException('Cannot move a chapter to a unit you do not own')
+
+    def is_editable(self, request):
+        return self.can_access(request) and request.user.has_perm('curricula.change_chapter')
 
     def get_absolute_url(self):
         return reverse('curriculum:chapter_view', args=[self.unit.curriculum.slug, self.unit.slug, self.number])

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -108,7 +108,7 @@ Vocabulary
 """
 
 
-class Vocab(Internationalizable, Ownable):
+class Vocab(Internationalizable, Filterable):
     word = models.CharField(max_length=255)
     simpleDef = models.TextField()
     detailDef = models.TextField(blank=True, null=True)
@@ -147,6 +147,12 @@ class Vocab(Internationalizable, Ownable):
             self.detailDef = self.simpleDef
         super(Vocab, self).save(*args, **kwargs)
 
+    def can_access(self, request):
+        return request.user.has_perm('lessons.access_all_vocab') or request.user.id == self.user_id
+
+    def is_editable(self, request):
+        return self.can_access(request) and request.user.has_perm('lessons.change_vocab')
+
 
 """
 Linked Resources
@@ -154,7 +160,7 @@ Linked Resources
 """
 
 
-class Resource(Orderable, Internationalizable, Ownable):
+class Resource(Orderable, Internationalizable, Filterable):
     name = models.CharField(max_length=255)
     type = models.CharField(max_length=255, blank=True, null=True)
     student = models.BooleanField('Student Facing', default=False)
@@ -322,6 +328,12 @@ class Resource(Orderable, Internationalizable, Ownable):
                 self.slug = '%s-%d' % (self.slug[:250], x)
 
         super(Resource, self).save(*args, **kwargs)
+
+    def can_access(self, request):
+        return request.user.has_perm('lessons.access_all_resources') or request.user.id == self.user_id
+
+    def is_editable(self, request):
+        return self.can_access(request) and request.user.has_perm('lessons.change_resource')
 
 
 """
@@ -797,7 +809,7 @@ Learning Objectives
 """
 
 
-class Objective(Orderable, Internationalizable, CloneableMixin, Ownable):
+class Objective(Orderable, Internationalizable, CloneableMixin, Filterable):
     name = models.CharField(max_length=255)
     description = models.TextField(blank=True, null=True)
     lesson = models.ForeignKey(Lesson)
@@ -830,6 +842,12 @@ class Objective(Orderable, Internationalizable, CloneableMixin, Ownable):
         self.user_id = self.user_id or self.lesson.user_id
 
         super(Objective, self).save(*args, **kwargs)
+
+    def can_access(self, request):
+        return request.user.has_perm('lessons.access_all_objectives') or request.user.id == self.user_id
+
+    def is_editable(self, request):
+        return self.can_access(request) and request.user.has_perm('lessons.change_objective')
 
 
 """


### PR DESCRIPTION
### Background

https://github.com/code-dot-org/curriculumbuilder/pull/173 added `Ownable` as a parent to several models, which broke inline editing because it overrode `is_editable` to ignore our existing `change_*` permissions.  A quick fix for this was made to `Lesson` and `Activity` (removed in this PR), to allow curriculum team members to regain inline editing privileges. However the following two problems remain:
1. partners (who do not have `access_all_*` permissions) **can** currently inline-edit any `Lesson` and `Activity` objects
2. curriculum team (who have `access_all_*` permissions) **cannot** currently inline-edit any `Curriculum` or `Unit` objects

### Description

This PR does the following:
1. extracts a `Filterable` interface which overrides `is_filterable` for all `Ownable` models
2. implements correct logic in `is_filterable` on all `Ownable` models to fix permissions for all user types

I'm stopping here (see Future Work) because these permission fixes are needed for the bug bash at 12:30pm PT on Tuesday.

### Future work

I could not figure out how to share make a class in `curricula.models` inherit from `lessons.models.Filterable`, perhaps due to a circular reference (both model files import the other). Because `Filterable` and `FilterableAdmin` really belong in a shared location, my plan is to extract these to somewhere like `core.models` in a subsequent PR. Ideas for this are welcome!

I also still owe tests for everything Ownable/Filterable.