### PR TITLE
Hide admin controls from partners on pages they do not own

### DIFF
--- a/curricula/templates/curricula/codestudiolesson.html
+++ b/curricula/templates/curricula/codestudiolesson.html
@@ -71,7 +71,7 @@
 <!-- Admin Toolbox -->
 {% block admin_link %}
 {% if user.is_staff %}
-    {% include "curricula/partials/admin_menu.html" with page=lesson pagetype="Lesson" %}
+    {% include "curricula/partials/admin_menu.html" with page=lesson pagetype="Lesson" can_administer=can_administer %}
 {% endif %}
 {% endblock %}
 

--- a/curricula/templates/curricula/hoc_lesson.html
+++ b/curricula/templates/curricula/hoc_lesson.html
@@ -124,14 +124,16 @@
                     <h2>deepSpaceCopy</h2>
                     <button class="btn btn-primary" id="clone_this" data-pk="{{ lesson.pk }}" data-type="Lesson">Clone</button><i id="clone_spinner"></i><br/>
                     <pre id="clone_results"></pre>
-                    <h2>Code Studio</h2>
-                    <button class="btn btn-primary" id="get_stage_details" data-pk="{{ lesson.pk }}" data-type="Lesson">
-                        Get Code Studio Stage Details
-                    </button>
-                    <i id="stage_progress_spinner"></i>
-                    <pre id="stage_details_results"></pre>
                 </div>
             {% endif %}
+            <div class="drawer-body">
+                <h2>Code Studio</h2>
+                <button class="btn btn-primary" id="get_stage_details" data-pk="{{ lesson.pk }}" data-type="Lesson">
+                    Get Code Studio Stage Details
+                </button>
+                <i id="stage_progress_spinner"></i>
+                <pre id="stage_details_results"></pre>
+            </div>
             <div class="drawer-body">
                 <h2>Resources</h2>
                 <ul>

--- a/curricula/templates/curricula/hoc_lesson.html
+++ b/curricula/templates/curricula/hoc_lesson.html
@@ -78,32 +78,33 @@
             <div class="drawer-heading">
                 <h2 class="drawer-title">Settings</h2>
             </div>
-            <div class="drawer-body">
-                <div class="checkbox settings">
-                    <label>
-                        <input type="checkbox" name="say">
-                        Show "Say" Prompts
-                    </label>
+            {% if can_administer %}
+                <div class="drawer-body">
+                    <div class="checkbox settings">
+                        <label>
+                            <input type="checkbox" name="say">
+                            Show "Say" Prompts
+                        </label>
+                    </div>
+                    <div class="checkbox settings">
+                        <label>
+                            <input type="checkbox" name="tip">
+                            Show Teaching Tips
+                        </label>
+                    </div>
+                    <div class="checkbox settings">
+                        <label>
+                            <input type="checkbox" name="discussion">
+                            Show Discussion Goals
+                        </label>
+                    </div>
+                    <div class="checkbox settings">
+                        <label>
+                            <input type="checkbox" name="content">
+                            Show Content Corners
+                        </label>
+                    </div>
                 </div>
-                <div class="checkbox settings">
-                    <label>
-                        <input type="checkbox" name="tip">
-                        Show Teaching Tips
-                    </label>
-                </div>
-                <div class="checkbox settings">
-                    <label>
-                        <input type="checkbox" name="discussion">
-                        Show Discussion Goals
-                    </label>
-                </div>
-                <div class="checkbox settings">
-                    <label>
-                        <input type="checkbox" name="content">
-                        Show Content Corners
-                    </label>
-                </div>
-            </div>
                 <div class="drawer-body">
                     <h2>Add to Log</h2>
                         <form method="POST" action="." class="post-form">{% csrf_token %}
@@ -129,21 +130,24 @@
                     </button>
                     <i id="stage_progress_spinner"></i>
                     <pre id="stage_details_results"></pre>
-                    <h2>Resources</h2>
-                    <ul>
-                        {% for resource in lesson.resources.all %}
-                            <li>{{ resource }}</li>
-                            <kbd draggable="true"
-                                 ondragstart="event.dataTransfer.setData('text/plain', '{{ resource.md_tag }}')">{{ resource.md_tag }}</kbd>
-                        {% endfor %}
-                    </ul>
-                    <h2>Vocab</h2>
-                    {% for vocab in lesson.vocab.all %}
-                        <li>{{ vocab.word }}</li>
-                        <kbd draggable="true"
-                             ondragstart="event.dataTransfer.setData('text/plain', '[v {{ vocab.word }}]')">[v {{ vocab.word }}]</kbd>
-                    {% endfor %}
                 </div>
+            {% endif %}
+            <div class="drawer-body">
+                <h2>Resources</h2>
+                <ul>
+                    {% for resource in lesson.resources.all %}
+                        <li>{{ resource }}</li>
+                        <kbd draggable="true"
+                             ondragstart="event.dataTransfer.setData('text/plain', '{{ resource.md_tag }}')">{{ resource.md_tag }}</kbd>
+                    {% endfor %}
+                </ul>
+                <h2>Vocab</h2>
+                {% for vocab in lesson.vocab.all %}
+                    <li>{{ vocab.word }}</li>
+                    <kbd draggable="true"
+                         ondragstart="event.dataTransfer.setData('text/plain', '[v {{ vocab.word }}]')">[v {{ vocab.word }}]</kbd>
+                {% endfor %}
+            </div>
             <ul class="drawer-nav">
             </ul>
         </div>

--- a/curricula/templates/curricula/partials/admin_menu.html
+++ b/curricula/templates/curricula/partials/admin_menu.html
@@ -9,44 +9,46 @@
         </div>
         <div class="drawer-body">
 
-            <h2>Add to Log</h2>
-            <form method="POST" action="." class="post-form">{% csrf_token %}
-                {{ form.as_p }}
-                <button type="submit" class="save btn btn-primary">Save</button>
-            </form>
-            {% if unit %}
-            <h3><a href="{% url 'curriculum:unit_feedback' curriculum.slug unit.slug %}">View unit feedback</a></h3>
-            {% endif %}
-            <h3><a href="{% url 'curriculum:page_history' page.pk %}">View history</a></h3>
-
-            <h2>Publishing</h2>
-            {% if page.jackfrost_can_build %}
-                <button class="btn btn-primary" id="publish_this" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">
-                    Publish
-                </button><i id="progress_spinner"></i>
-                <input type="checkbox" name="lessons" id="include_lessons"> Include Children</input>
-                <pre id="publish_results"></pre>
-                {% if pagetype == "Unit" %}
-                <button class="btn btn-primary" id="publish_pdfs" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">Publish PDFs</button><i id="progress_spinner_pdf" style="margin: 5px;"></i><br/>
-                <pre id="publish_results_pdf"></pre>
+            {% if can_administer %}
+                <h2>Add to Log</h2>
+                <form method="POST" action="." class="post-form">{% csrf_token %}
+                    {{ form.as_p }}
+                    <button type="submit" class="save btn btn-primary">Save</button>
+                </form>
+                {% if unit %}
+                <h3><a href="{% url 'curriculum:unit_feedback' curriculum.slug unit.slug %}">View unit feedback</a></h3>
                 {% endif %}
-            {% else %}
-                <em>Can't publish, check settings in admin</em>
+                <h3><a href="{% url 'curriculum:page_history' page.pk %}">View history</a></h3>
+
+                <h2>Publishing</h2>
+                {% if page.jackfrost_can_build %}
+                    <button class="btn btn-primary" id="publish_this" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">
+                        Publish
+                    </button><i id="progress_spinner"></i>
+                    <input type="checkbox" name="lessons" id="include_lessons"> Include Children</input>
+                    <pre id="publish_results"></pre>
+                    {% if pagetype == "Unit" %}
+                    <button class="btn btn-primary" id="publish_pdfs" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">Publish PDFs</button><i id="progress_spinner_pdf" style="margin: 5px;"></i><br/>
+                    <pre id="publish_results_pdf"></pre>
+                    {% endif %}
+                {% else %}
+                    <em>Can't publish, check settings in admin</em>
+                {% endif %}
+
+                <h2>deepSpaceCopy</h2>
+                <button class="btn btn-primary" id="clone_this" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">Clone</button>
+                <input type="checkbox" name="children" id="clone_children"> Clone Children</input>
+                <i id="clone_spinner"></i><br/>
+                {% comment %} ToDo: add ability to clone into a different parent {% endcomment %}
+                <pre id="clone_results"></pre>
+
+                <h2>Code Studio</h2>
+                <button class="btn btn-primary" id="get_stage_details" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">
+                    Get Code Studio Stage Details
+                </button>
+                <i id="stage_progress_spinner"></i>
+                <pre id="stage_details_results"></pre>
             {% endif %}
-
-            <h2>deepSpaceCopy</h2>
-            <button class="btn btn-primary" id="clone_this" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">Clone</button>
-            <input type="checkbox" name="children" id="clone_children"> Clone Children</input>
-            <i id="clone_spinner"></i><br/>
-            {% comment %} ToDo: add ability to clone into a different parent {% endcomment %}
-            <pre id="clone_results"></pre>
-
-            <h2>Code Studio</h2>
-            <button class="btn btn-primary" id="get_stage_details" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">
-                Get Code Studio Stage Details
-            </button>
-            <i id="stage_progress_spinner"></i>
-            <pre id="stage_details_results"></pre>
 
             {% if pagetype == "Lesson" %}
             <h2>Resources</h2>

--- a/curricula/templates/curricula/partials/admin_menu.html
+++ b/curricula/templates/curricula/partials/admin_menu.html
@@ -41,14 +41,14 @@
                 <i id="clone_spinner"></i><br/>
                 {% comment %} ToDo: add ability to clone into a different parent {% endcomment %}
                 <pre id="clone_results"></pre>
-
-                <h2>Code Studio</h2>
-                <button class="btn btn-primary" id="get_stage_details" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">
-                    Get Code Studio Stage Details
-                </button>
-                <i id="stage_progress_spinner"></i>
-                <pre id="stage_details_results"></pre>
             {% endif %}
+
+            <h2>Code Studio</h2>
+            <button class="btn btn-primary" id="get_stage_details" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">
+                Get Code Studio Stage Details
+            </button>
+            <i id="stage_progress_spinner"></i>
+            <pre id="stage_details_results"></pre>
 
             {% if pagetype == "Lesson" %}
             <h2>Resources</h2>

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -248,6 +248,9 @@ def lesson_view(request, slug, unit_slug, lesson_num, optional_num=False):
 
     changelog = Version.objects.get_for_object(lesson).filter(revision__user__username=settings.CHANGELOG_USER)
 
+    # disable admin controls if user cannot edit inline
+    can_administer = lesson.is_editable(request)
+
     if lesson.unit.lesson_template_override:
         template = lesson.unit.lesson_template_override
     else:
@@ -255,7 +258,8 @@ def lesson_view(request, slug, unit_slug, lesson_num, optional_num=False):
 
     return render(request, template,
                   {'curriculum': lesson.curriculum, 'unit': lesson.unit, 'chapter': chapter, 'lesson': lesson,
-                   'pdf': pdf, 'parent': parent, 'optional': optional, 'form': form, 'changelog': changelog})
+                   'pdf': pdf, 'parent': parent, 'optional': optional, 'form': form, 'changelog': changelog,
+                   'can_administer': can_administer})
 
 
 def lesson_markdown(request, slug, unit_slug, lesson_num):


### PR DESCRIPTION
In response to bug bash feedback, this PR hides the admin controls in the settings menu for partners who are viewing a page which they do not own. This includes the following buttons: Publish, Publish PDFs, Clone,  Get Code Studio Stage Details.

The Resources and Vocab sections are preserved, because those are useful when viewing lessons you don't own.

## before

lesson | hoc lesson
--- | --- 
![Screen Shot 2019-10-29 at 2 38 10 PM](https://user-images.githubusercontent.com/8001765/67811352-cbd0c180-fa59-11e9-8cf3-195d903ffa00.png) | ![Screen Shot 2019-10-29 at 2 00 53 PM](https://user-images.githubusercontent.com/8001765/67811268-9f1caa00-fa59-11e9-9316-002d35a0f416.png)

## after

lesson | hoc lesson
--- | --- 
![Screen Shot 2019-10-29 at 2 38 22 PM](https://user-images.githubusercontent.com/8001765/67811378-d7bc8380-fa59-11e9-9ba3-d26caac6fd6d.png) | ![Screen Shot 2019-10-29 at 2 01 09 PM](https://user-images.githubusercontent.com/8001765/67811367-d25f3900-fa59-11e9-966b-d1cb147b4d4e.png)
