### PR TITLE
extract factory classes from curricula rendering tests

### DIFF
--- a/curricula/factories.py
+++ b/curricula/factories.py
@@ -1,7 +1,17 @@
-from factory import Sequence
+from django.contrib.auth.models import User
+
+from factory import Sequence, PostGenerationMethodCall
 from factory.django import DjangoModelFactory
 
 from curricula.models import Curriculum
+
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+        model = User
+
+    username = Sequence(lambda n: "user_%d" % n)
+    password = PostGenerationMethodCall('set_password', 'password')
 
 class CurriculumFactory(DjangoModelFactory):
     class Meta:

--- a/curricula/factories.py
+++ b/curricula/factories.py
@@ -1,0 +1,12 @@
+from factory import Sequence
+from factory.django import DjangoModelFactory
+
+from curricula.models import Curriculum
+
+class CurriculumFactory(DjangoModelFactory):
+    class Meta:
+        model = Curriculum
+
+    title = Sequence(lambda n: "Test Curriculum %03d" % n)
+    slug = Sequence(lambda n: "test-curriculum-%03d" % n)
+    assessment_commentary = "Assessment Commentary"

--- a/curricula/factories.py
+++ b/curricula/factories.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from factory import Sequence, PostGenerationMethodCall, SubFactory
 from factory.django import DjangoModelFactory
 
-from curricula.models import Curriculum
+from curricula.models import Curriculum, Unit
 
 
 class UserFactory(DjangoModelFactory):
@@ -20,4 +20,13 @@ class CurriculumFactory(DjangoModelFactory):
     title = Sequence(lambda n: "Test Curriculum %03d" % n)
     slug = Sequence(lambda n: "test-curriculum-%03d" % n)
     assessment_commentary = "Assessment Commentary"
+    user = SubFactory('curricula.factories.UserFactory')
+
+class UnitFactory(DjangoModelFactory):
+    class Meta:
+        model = Unit
+
+    title = Sequence(lambda n: "Test Unit %03d" % n)
+    slug = Sequence(lambda n: "test-unit-%03d" % n)
+    description = "unit description"
     user = SubFactory('curricula.factories.UserFactory')

--- a/curricula/factories.py
+++ b/curricula/factories.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import User
 
-from factory import Sequence, PostGenerationMethodCall
+from factory import Sequence, PostGenerationMethodCall, SubFactory
 from factory.django import DjangoModelFactory
 
 from curricula.models import Curriculum
@@ -20,3 +20,4 @@ class CurriculumFactory(DjangoModelFactory):
     title = Sequence(lambda n: "Test Curriculum %03d" % n)
     slug = Sequence(lambda n: "test-curriculum-%03d" % n)
     assessment_commentary = "Assessment Commentary"
+    user = SubFactory('curricula.factories.UserFactory')

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -15,15 +15,13 @@ class CurriculaRenderingTestCase(TestCase):
         self.user = user
         self.client.login(username=user.username, password='password')
 
-        self.test_curriculum = CurriculumFactory(slug="test-curriculum", user=user)
+        self.test_curriculum = CurriculumFactory(slug="test-curriculum")
         self.csf_curriculum = CurriculumFactory(
             slug="csf-curriculum",
-            unit_template_override='curricula/csf_unit.html',
-            user=user)
+            unit_template_override='curricula/csf_unit.html')
         self.pl_curriculum = CurriculumFactory(
             slug="pl-curriculum",
-            unit_template_override='curricula/pl_unit.html',
-            user=user)
+            unit_template_override='curricula/pl_unit.html')
         self.test_unit = Unit.objects.create(
             title="Test Unit",
             parent=self.test_curriculum,

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -1,8 +1,5 @@
 from django.test import TestCase
-from django.contrib.auth.models import User, Permission
-
-from curricula.models import Curriculum, Unit
-from lessons.models import Lesson, Resource
+from django.contrib.auth.models import Permission
 
 from curricula.factories import UserFactory, CurriculumFactory, UnitFactory
 from lessons.factories import LessonFactory, ResourceFactory

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User, Permission
 from curricula.models import Curriculum, Unit
 from lessons.models import Lesson, Resource
 
-from curricula.factories import UserFactory, CurriculumFactory
+from curricula.factories import UserFactory, CurriculumFactory, UnitFactory
 
 
 class CurriculaRenderingTestCase(TestCase):
@@ -22,34 +22,19 @@ class CurriculaRenderingTestCase(TestCase):
         self.pl_curriculum = CurriculumFactory(
             slug="pl-curriculum",
             unit_template_override='curricula/pl_unit.html')
-        self.test_unit = Unit.objects.create(
-            title="Test Unit",
-            parent=self.test_curriculum,
-            slug="test-unit",
-            description="Test unit description",
-            show_calendar=True,
-            user=user)
-        self.hoc_unit = Unit.objects.create(
-            title="HoC Unit",
+        self.test_unit = UnitFactory(parent=self.test_curriculum, slug="test-unit")
+        self.hoc_unit = UnitFactory(
             parent=self.test_curriculum,
             slug="hoc-unit",
-            description="Hoc unit description",
-            lesson_template_override="curricula/hoc_lesson.html",
-            user=user)
-        self.csf_unit = Unit.objects.create(
-            title="CSF Unit",
+            lesson_template_override="curricula/hoc_lesson.html")
+        self.csf_unit = UnitFactory(
             parent=self.csf_curriculum,
             slug="csf-unit",
-            description="CSF unit description",
-            lesson_template_override="curricula/csf_lesson.html",
-            user=user)
-        self.pl_unit = Unit.objects.create(
-            title="PL Unit",
+            lesson_template_override="curricula/csf_lesson.html")
+        self.pl_unit = UnitFactory(
             parent=self.pl_curriculum,
             slug="pl-unit",
-            description="PL unit description",
-            lesson_template_override="curricula/pl_lesson.html",
-            user=user)
+            lesson_template_override="curricula/pl_lesson.html")
         resource = Resource.objects.create(
             name="Test Resource",
             slug="test-resource",

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -90,7 +90,6 @@ class CurriculaRenderingTestCase(TestCase):
     def test_lesson_admin_menu(self):
         response = self.client.get('/test-curriculum/test-unit/1/')
         self.assertEqual(response.status_code, 200)
-        # print(response.content)
         self.assertIn('admin_edit', response.content)
         self.assertNotIn('deepSpaceCopy', response.content)
         response = self.client.get('/test-curriculum/hoc-unit/1/')

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -5,7 +5,7 @@ from curricula.models import Curriculum, Unit
 from lessons.models import Lesson, Resource
 
 from curricula.factories import UserFactory, CurriculumFactory, UnitFactory
-from lessons.factories import LessonFactory
+from lessons.factories import LessonFactory, ResourceFactory
 
 
 class CurriculaRenderingTestCase(TestCase):
@@ -36,11 +36,7 @@ class CurriculaRenderingTestCase(TestCase):
             parent=self.pl_curriculum,
             slug="pl-unit",
             lesson_template_override="curricula/pl_lesson.html")
-        resource = Resource.objects.create(
-            name="Test Resource",
-            slug="test-resource",
-            student=True,
-            user=user)
+        resource = ResourceFactory()
         self.test_lesson = LessonFactory(parent=self.test_unit)
         self.test_lesson.resources.add(resource)
         self.hoc_lesson = LessonFactory(parent=self.hoc_unit)

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -101,7 +101,6 @@ class CurriculaRenderingTestCase(TestCase):
         self.user.user_permissions.add(permission)
         permission = Permission.objects.get(codename='access_all_lessons')
         self.user.user_permissions.add(permission)
-        self.user.save()
 
         # Copy button appears in admin menu for users with sufficient permissions
         response = self.client.get('/test-curriculum/test-unit/1/')

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -4,6 +4,8 @@ from django.contrib.auth.models import User, Permission
 from curricula.models import Curriculum, Unit
 from lessons.models import Lesson, Resource
 
+from curricula.factories import CurriculumFactory
+
 
 class CurriculaRenderingTestCase(TestCase):
     def setUp(self):
@@ -13,7 +15,7 @@ class CurriculaRenderingTestCase(TestCase):
         user.save()
         self.client.login(username='admin', password='12345')
 
-        self.test_curriculum = Curriculum.objects.create(
+        self.test_curriculum = CurriculumFactory(
             title="Test Curriculum",
             slug="test-curriculum",
             assessment_commentary="Assessment Commentary",

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -4,16 +4,16 @@ from django.contrib.auth.models import User, Permission
 from curricula.models import Curriculum, Unit
 from lessons.models import Lesson, Resource
 
-from curricula.factories import CurriculumFactory
+from curricula.factories import UserFactory, CurriculumFactory
 
 
 class CurriculaRenderingTestCase(TestCase):
     def setUp(self):
-        user = User.objects.create_user(username='admin', password='12345')
-        self.user = user
+        user = UserFactory()
         user.is_staff = True
         user.save()
-        self.client.login(username='admin', password='12345')
+        self.user = user
+        self.client.login(username=user.username, password='password')
 
         self.test_curriculum = CurriculumFactory(slug="test-curriculum", user=user)
         self.csf_curriculum = CurriculumFactory(
@@ -133,6 +133,7 @@ class CurriculaRenderingTestCase(TestCase):
     def test_lesson_admin_menu(self):
         response = self.client.get('/test-curriculum/test-unit/1/')
         self.assertEqual(response.status_code, 200)
+        # print(response.content)
         self.assertIn('admin_edit', response.content)
         self.assertNotIn('deepSpaceCopy', response.content)
         response = self.client.get('/test-curriculum/hoc-unit/1/')
@@ -144,6 +145,7 @@ class CurriculaRenderingTestCase(TestCase):
         self.user.user_permissions.add(permission)
         permission = Permission.objects.get(codename='access_all_lessons')
         self.user.user_permissions.add(permission)
+        self.user.save()
 
         # Copy button appears in admin menu for users with sufficient permissions
         response = self.client.get('/test-curriculum/test-unit/1/')

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -15,21 +15,13 @@ class CurriculaRenderingTestCase(TestCase):
         user.save()
         self.client.login(username='admin', password='12345')
 
-        self.test_curriculum = CurriculumFactory(
-            title="Test Curriculum",
-            slug="test-curriculum",
-            assessment_commentary="Assessment Commentary",
-            user=user)
-        self.csf_curriculum = Curriculum.objects.create(
-            title="CSF Curriculum",
+        self.test_curriculum = CurriculumFactory(slug="test-curriculum", user=user)
+        self.csf_curriculum = CurriculumFactory(
             slug="csf-curriculum",
-            assessment_commentary="CSF Commentary",
             unit_template_override='curricula/csf_unit.html',
             user=user)
-        self.pl_curriculum = Curriculum.objects.create(
-            title="PL Curriculum",
+        self.pl_curriculum = CurriculumFactory(
             slug="pl-curriculum",
-            assessment_commentary="PL Commentary",
             unit_template_override='curricula/pl_unit.html',
             user=user)
         self.test_unit = Unit.objects.create(

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -5,6 +5,7 @@ from curricula.models import Curriculum, Unit
 from lessons.models import Lesson, Resource
 
 from curricula.factories import UserFactory, CurriculumFactory, UnitFactory
+from lessons.factories import LessonFactory
 
 
 class CurriculaRenderingTestCase(TestCase):
@@ -40,33 +41,13 @@ class CurriculaRenderingTestCase(TestCase):
             slug="test-resource",
             student=True,
             user=user)
-        self.test_lesson = Lesson.objects.create(
-            title="Test Lesson",
-            parent=self.test_unit,
-            overview="Overview",
-            prep="Prep",
-            user=user)
+        self.test_lesson = LessonFactory(parent=self.test_unit)
         self.test_lesson.resources.add(resource)
-        self.hoc_lesson = Lesson.objects.create(
-            title="HoC Lesson",
-            parent=self.hoc_unit,
-            overview="HoC Overview",
-            prep="Prep",
-            user=user)
+        self.hoc_lesson = LessonFactory(parent=self.hoc_unit)
         self.hoc_lesson.resources.add(resource)
-        self.csf_lesson = Lesson.objects.create(
-            title="CSF Lesson",
-            parent=self.csf_unit,
-            overview="CSF Overview",
-            prep="Prep",
-            user=user)
+        self.csf_lesson = LessonFactory(parent=self.csf_unit)
         self.csf_lesson.resources.add(resource)
-        self.pl_lesson = Lesson.objects.create(
-            title="PL Lesson",
-            parent=self.pl_unit,
-            overview="PL Overview",
-            prep="Prep",
-            user=user)
+        self.pl_lesson = LessonFactory(parent=self.pl_unit)
         self.pl_lesson.resources.add(resource)
 
     def test_homepage(self):

--- a/lessons/factories.py
+++ b/lessons/factories.py
@@ -1,0 +1,14 @@
+from factory import Sequence, SubFactory
+from factory.django import DjangoModelFactory
+
+from lessons.models import Lesson
+
+class LessonFactory(DjangoModelFactory):
+    class Meta:
+        model = Lesson
+
+    title = Sequence(lambda n: "Test Lesson %03d" % n)
+    slug = Sequence(lambda n: "test-lesson-%03d" % n)
+    overview = 'overview'
+    prep = 'prep'
+    user = SubFactory('curricula.factories.UserFactory')

--- a/lessons/factories.py
+++ b/lessons/factories.py
@@ -1,7 +1,7 @@
 from factory import Sequence, SubFactory
 from factory.django import DjangoModelFactory
 
-from lessons.models import Lesson
+from lessons.models import Lesson, Resource
 
 class LessonFactory(DjangoModelFactory):
     class Meta:
@@ -11,4 +11,13 @@ class LessonFactory(DjangoModelFactory):
     slug = Sequence(lambda n: "test-lesson-%03d" % n)
     overview = 'overview'
     prep = 'prep'
+    user = SubFactory('curricula.factories.UserFactory')
+
+class ResourceFactory(DjangoModelFactory):
+    class Meta:
+        model = Resource
+
+    name = Sequence(lambda n: "Test Resource %03d" % n)
+    slug = Sequence(lambda n: "test-resource-%03d" % n)
+    student = True
     user = SubFactory('curricula.factories.UserFactory')

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ djangorestframework==3.3.1
 djangorestframework-recursive==0.1.1
 docutils
 #dryscrape
+factory-boy==2.12.0
 filebrowser-safe==0.4.1
 future==0.15.2
 -e git://github.com/mrjoshida/django-csvimport.git@master#egg=django_csvimport


### PR DESCRIPTION
extracting factories for django model classes via [factory boy](https://factoryboy.readthedocs.io/en/latest/introduction.html) turned out to be a piece of cake once I realized that I needed to use their `factory.django.DjangoModelFactory` class instead of their more general `factory.Factory` class. I mostly followed these recipes: https://factoryboy.readthedocs.io/en/latest/recipes.html one gotcha is also documented inline.

This should set us up well to add more tests around permissions without so much setup code bloat.