### PR TITLE
send staff users to /admin on 403

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -7,6 +7,7 @@
         {% if request.user.is_staff %}
             window.location = "/admin";
         {% else %}
+            {% comment %} avoid redirect loops for non-staff users {% endcomment %}
             window.location = "https://code.org/educate";
         {% endif %}
     </script>

--- a/templates/403.html
+++ b/templates/403.html
@@ -7,7 +7,7 @@
         {% if request.user.is_staff %}
             window.location = "/admin";
         {% else %}
-            window.location = "https://code.org/learn";
+            window.location = "https://code.org/educate";
         {% endif %}
     </script>
 </head>

--- a/templates/403.html
+++ b/templates/403.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8">
     <title>403</title>
     <script type="text/javascript">
-    window.location = "https://code.org/educate";
+        {% if request.user.is_staff %}
+            window.location = "/admin";
+        {% else %}
+            window.location = "https://code.org/learn";
+        {% endif %}
     </script>
 </head>
 <body>


### PR DESCRIPTION
This makes it so that when Broward clicks these links on pages they don't own, they'll be taken to codecurricula.com/admin instead of studio.code.org/courses:
![Screen Shot 2019-10-30 at 11 25 12 AM](https://user-images.githubusercontent.com/8001765/67887247-2a547900-fb08-11e9-9772-cb226588cd37.png)

docs on django error views can be found here: https://docs.djangoproject.com/en/2.2/ref/views/#error-views but basically the existing 403.html file is the default location for the error template that gets rendered when a permission denied error occurs. `request` is the only accessible object in that view, unless you define a custom `handler403` view.