### PR TITLE
Add the PR Template to Curriculum Builder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+# Description
+
+<!--
+  A summary of the change, including any relevant motivation and context.
+
+  If relevant, include a description both of the existing behavior and of the new behavior.
+-->
+
+<!--
+  Other aspects to consider. uncomment and add detail for any that seem necessary:
+-->
+
+<!-- ### Background -->
+<!-- ### Privacy -->
+<!-- ### Security -->
+<!-- ### Caching -->
+<!-- ### Testing -->
+<!-- ### Deployment strategy -->
+<!-- ### Future work -->
+
+## Links
+
+<!--
+  Any relevant links to external resources; ie, specification documents, jira
+  items, related PRs, honeybadger errors, etc
+-->
+
+- [spec]()
+- [jira]()
+
+## Testing story
+
+<!--
+  Does your change include appropriate tests?
+
+  If so, please describe how the tests included in this PR are sufficient
+
+  If not, please explain why this change does not need to be tested.
+-->
+
+# Reviewer Checklist:
+
+- [ ] Tests provide adequate coverage
+- [ ] Code is well-commented
+- [ ] New features are translatable or updates will not break translations
+- [ ] Relevant documentation has been added or updated
+- [ ] User impact is well-understood and desirable
+- [ ] Pull Request is labeled appropriately
+- [ ] Follow-up work items (including potential tech debt) are tracked and linked


### PR DESCRIPTION
Elijah added a PR template to the normal code repo: https://github.com/code-dot-org/code-dot-org/pull/30930

This adds that PR template to Curriculum Builder.