### PR TITLE
Filter privileged resource fields

### DIFF
--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -436,10 +436,12 @@ class ResourceAdmin(AjaxSelectAdmin, ImportExportModelAdmin, FilterableAdmin):
     list_editable = ('type', 'student', 'gd', 'url', 'dl_url')
     list_filter = ('lessons__curriculum',)
     inlines = [LessonResourceInline]
-    fields = ['name', 'type', 'student', 'gd', 'url', 'dl_url', 'slug', 'force_i18n']
 
     def can_access_all(self, request):
         return request.user.has_perm('lessons.access_all_resources')
+
+    def get_fields(self, request, obj=None):
+        return ['name', 'type', 'student', 'gd', 'url', 'dl_url', 'slug', 'force_i18n']
 
 
 class VocabAdmin(ImportExportModelAdmin, FilterableAdmin):

--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -441,7 +441,14 @@ class ResourceAdmin(AjaxSelectAdmin, ImportExportModelAdmin, FilterableAdmin):
         return request.user.has_perm('lessons.access_all_resources')
 
     def get_fields(self, request, obj=None):
-        return ['name', 'type', 'student', 'gd', 'url', 'dl_url', 'slug', 'force_i18n']
+        fields = ['name', 'type', 'student', 'gd', 'url', 'dl_url', 'slug']
+
+        # Use access_all permissions as a proxy for admin privileges, to
+        # exclude non-admins (such as partners) from editing certain fields.
+        if self.can_access_all(request):
+            fields.append('force_i18n')
+
+        return fields
 
 
 class VocabAdmin(ImportExportModelAdmin, FilterableAdmin):

--- a/lessons/tests.py
+++ b/lessons/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/lessons/tests/test_lessons_admin.py
+++ b/lessons/tests/test_lessons_admin.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+
+from curricula.factories import UserFactory
+
+
+# Tests for admin pages in lessons/admin.py
+class LessonsAdminTestCase(TestCase):
+
+    def setUp(self):
+        user = UserFactory()
+        user.is_staff = True
+        user.save()
+        self.user = user
+        self.client.login(username=user.username, password='password')
+
+    def test_render_add_resource(self):
+        response = self.client.get('/admin/lessons/resource/add/')
+        self.assertEqual(response.status_code, 200)

--- a/lessons/tests/test_lessons_admin.py
+++ b/lessons/tests/test_lessons_admin.py
@@ -1,4 +1,8 @@
 from django.test import TestCase
+from django.contrib.auth.models import Permission
+from django.contrib.sites.models import Site
+
+from mezzanine.core.models import SitePermission
 
 from curricula.factories import UserFactory
 
@@ -11,8 +15,27 @@ class LessonsAdminTestCase(TestCase):
         user.is_staff = True
         user.save()
         self.user = user
-        self.client.login(username=user.username, password='password')
+        self.assertTrue(self.client.login(username=user.username, password='password'))
+
+        site = Site.objects.first()
+        siteperms = SitePermission.objects.create(user=user)
+        siteperms.sites.add(site)
 
     def test_render_add_resource(self):
+        permission = Permission.objects.get(codename='add_resource')
+        self.user.user_permissions.add(permission)
+
         response = self.client.get('/admin/lessons/resource/add/')
         self.assertEqual(response.status_code, 200)
+        self.assertIn('Add resource', response.content)
+        self.assertIn('Download URL', response.content)
+        self.assertNotIn('Force I18n', response.content, 'privileged field should not be visible')
+
+        permission = Permission.objects.get(codename='access_all_resources')
+        self.user.user_permissions.add(permission)
+
+        response = self.client.get('/admin/lessons/resource/add/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Add resource', response.content)
+        self.assertIn('Download URL', response.content)
+        self.assertIn('Force I18n', response.content, 'privileged field should be visible')


### PR DESCRIPTION
# Background

Yesterday's bug bash revealed that there are many fields we want to hide from platformization partners such as Broward. 

# Description

Hide the Force I18n field from the Resource admin page for users without the `access_all_resources` permission. As noted in comments, this permission now serves as a proxy for what might better be named "administer resources". The plan is to hold off on renaming it until we see what our other needs might be as Broward starts to work with Curriculum Builder.

## Links

The following docs show APIs related to dynamic fields and fieldsets:
https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_fields
https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_fieldsets

Unfortunately, certain related methods such as [get_exclude](https://docs.djangoproject.com/en/1.11/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_exclude) won't be available until we upgrade to at least Django 1.11, which happens to be the last version of Django which supports Python 2.


## Testing story

New unit tests verify that the privileged field is hidden for those without `access_all_resources` permissions.

# Reviewer Checklist:

- [x] Tests provide adequate coverage
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
