### PR TITLE
Filter privileged fields on lesson admin page

### DIFF
--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -317,28 +317,30 @@ class LessonAdmin(PageAdmin, AjaxSelectAdmin, CompareVersionAdmin, FilterableAdm
 
     filter_horizontal = ('standards', 'opportunity_standards', 'vocab', 'blocks')
 
-    fieldsets = (
-        (None, {
-            'fields': ['title', 'short_title', ('status', 'login_required', 'week', 'duration', 'pacing_weight', 'unplugged'), 'image',
-                       'overview', 'keywords', ('description', 'gen_description')],
-        }),
-        ('Assessment', {
-            'fields': ['assessment'],
-            'classes': ['collapse-closed'],
-        }),
-        ('Purpose, Prep, & Questions', {
-            'fields': ['cs_content', 'prep', 'questions'],
-            'classes': ['collapse-closed'],
-        }),
-        ('Vocab & Blocks', {
-            'fields': ['vocab', 'blocks'],
-            'classes': ['collapse-closed'],
-        }),
-        ('Standards', {
-            'fields': ['standards', 'opportunity_standards'],
-            'classes': ['collapse-closed'],
-        }),
-    )
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = (
+            (None, {
+                'fields': ['title', 'short_title', ('status', 'login_required', 'week', 'duration', 'pacing_weight', 'unplugged'), 'image',
+                           'overview', 'keywords', ('description', 'gen_description')],
+            }),
+            ('Assessment', {
+                'fields': ['assessment'],
+                'classes': ['collapse-closed'],
+            }),
+            ('Purpose, Prep, & Questions', {
+                'fields': ['cs_content', 'prep', 'questions'],
+                'classes': ['collapse-closed'],
+            }),
+            ('Vocab & Blocks', {
+                'fields': ['vocab', 'blocks'],
+                'classes': ['collapse-closed'],
+            }),
+            ('Standards', {
+                'fields': ['standards', 'opportunity_standards'],
+                'classes': ['collapse-closed'],
+            }),
+        )
+        return fieldsets
 
     def compare_activity(self, obj_compare):
         """ compare the foo_bar model field """

--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -318,9 +318,16 @@ class LessonAdmin(PageAdmin, AjaxSelectAdmin, CompareVersionAdmin, FilterableAdm
     filter_horizontal = ('standards', 'opportunity_standards', 'vocab', 'blocks')
 
     def get_fieldsets(self, request, obj=None):
+        # In the admin UI, the login_required field is named "Hidden". Use the
+        # access_all permission to exclude partners from editing this field.
+        if self.can_access_all(request):
+            status_fields = ('status', 'login_required', 'week', 'duration', 'pacing_weight', 'unplugged',)
+        else:
+            status_fields = ('status', 'week', 'duration', 'pacing_weight', 'unplugged',)
+
         fieldsets = (
             (None, {
-                'fields': ['title', 'short_title', ('status', 'login_required', 'week', 'duration', 'pacing_weight', 'unplugged'), 'image',
+                'fields': ['title', 'short_title', status_fields, 'image',
                            'overview', 'keywords', ('description', 'gen_description')],
             }),
             ('Assessment', {

--- a/lessons/tests/test_lessons_admin.py
+++ b/lessons/tests/test_lessons_admin.py
@@ -39,3 +39,20 @@ class LessonsAdminTestCase(TestCase):
         self.assertIn('Add resource', response.content)
         self.assertIn('Download URL', response.content)
         self.assertIn('Force I18n', response.content, 'privileged field should be visible')
+
+    def test_render_add_lesson(self):
+        permission = Permission.objects.get(codename='add_lesson')
+        self.user.user_permissions.add(permission)
+
+        response = self.client.get('/admin/lessons/lesson/add/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Add lesson', response.content)
+        self.assertNotIn('Hide from listings', response.content, 'privileged field should not be visible')
+
+        permission = Permission.objects.get(codename='access_all_lessons')
+        self.user.user_permissions.add(permission)
+
+        response = self.client.get('/admin/lessons/lesson/add/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Add lesson', response.content)
+        self.assertIn('Hide from listings', response.content, 'privileged field should be visible')


### PR DESCRIPTION

# Description

Follow-on to https://github.com/code-dot-org/curriculumbuilder/pull/187 . Hides the "Hidden" field from the Lesson admin page. Uses fieldsets instead of fields.

## Testing story

New unit tests added to verify contents of lesson admin page with and without access_all permissions.

## Screenshots

![Screen Shot 2019-10-30 at 3 00 53 PM](https://user-images.githubusercontent.com/8001765/67902458-77474800-fb26-11e9-867a-5482be921481.png)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
