### PR TITLE
Fix regression which caused publish button to disappear

### DIFF
--- a/curricula/templates/curricula/curriculum.html
+++ b/curricula/templates/curricula/curriculum.html
@@ -32,7 +32,7 @@
 
 {% block admin_link %}
 {% if user.is_staff %}
-    {% include "curricula/partials/admin_menu.html" with page=curriculum pagetype="Curriculum" %}
+    {% include "curricula/partials/admin_menu.html" with page=curriculum pagetype="Curriculum" can_administer=can_administer %}
 {% endif %}
 {% endblock %}
 

--- a/curricula/templates/curricula/pl_curriculum.html
+++ b/curricula/templates/curricula/pl_curriculum.html
@@ -31,7 +31,7 @@
 
 {% block admin_link %}
 {% if user.is_staff %}
-    {% include "curricula/partials/admin_menu.html" with page=curriculum pagetype="Curriculum" %}
+    {% include "curricula/partials/admin_menu.html" with page=curriculum pagetype="Curriculum" can_administer=can_administer %}
 {% endif %}
 {% endblock %}
 

--- a/curricula/templates/curricula/pl_lesson.html
+++ b/curricula/templates/curricula/pl_lesson.html
@@ -69,7 +69,7 @@
 <!-- Admin Toolbox -->
 {% block admin_link %}
 {% if user.is_staff %}
-    {% include "curricula/partials/admin_menu.html" with page=lesson pagetype="Lesson" %}
+    {% include "curricula/partials/admin_menu.html" with page=lesson pagetype="Lesson" can_administer=can_administer %}
 {% endif %}
 {% endblock %}
 

--- a/curricula/templates/curricula/pl_unit.html
+++ b/curricula/templates/curricula/pl_unit.html
@@ -28,7 +28,7 @@
 
 {% block admin_link %}
 {% if user.is_staff %}
-    {% include "curricula/partials/admin_menu.html" with page=unit pagetype="Unit" %}
+    {% include "curricula/partials/admin_menu.html" with page=unit pagetype="Unit" can_administer=can_administer %}
 {% endif %}
 {% endblock %}
 

--- a/curricula/templates/curricula/unit.html
+++ b/curricula/templates/curricula/unit.html
@@ -29,7 +29,7 @@
 
 {% block admin_link %}
 {% if user.is_staff %}
-    {% include "curricula/partials/admin_menu.html" with page=unit pagetype="Unit" %}
+    {% include "curricula/partials/admin_menu.html" with page=unit pagetype="Unit" can_administer=can_administer %}
 {% endif %}
 {% endblock %}
 

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -146,6 +146,9 @@ def unit_view(request, slug, unit_slug):
 
     changelog = Version.objects.get_for_object(unit).filter(revision__user__username=settings.CHANGELOG_USER)
 
+    # disable admin controls if user cannot edit inline
+    can_administer = unit.is_editable(request)
+
     if pdf:
         if curriculum.unit_template_override == 'curricula/pl_unit.html':
             template = 'curricula/pl_unit_lessons.html'
@@ -158,7 +161,7 @@ def unit_view(request, slug, unit_slug):
             template = 'curricula/unit.html'
 
     return render(request, template, {'curriculum': curriculum, 'unit': unit, 'pdf': pdf,
-                                      'form': form, 'changelog': changelog})
+                                      'form': form, 'changelog': changelog, 'can_administer': can_administer})
 
 
 def unit_at_a_glance(request, slug, unit_slug):

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -107,8 +107,12 @@ def curriculum_view(request, slug):
 
     changelog = Version.objects.get_for_object(curriculum).filter(revision__user__username=settings.CHANGELOG_USER)
 
+    # disable admin controls if user cannot edit inline
+    can_administer = curriculum.is_editable(request)
+
     return render(request, 'curricula/curriculum.html', {'curriculum': curriculum, 'pdf': pdf, 'units': units,
-                                                         'form': form, 'changelog': changelog})
+                                                         'form': form, 'changelog': changelog,
+                                                         'can_administer': can_administer})
 
 
 # @login_required


### PR DESCRIPTION
# Description

https://github.com/code-dot-org/curriculumbuilder/pull/183 hid the admin menu (publish button, etc) for partners on lesson pages, while continuing to allow authors with `access_all` permissions to publish. Unfortunately, this hid the admin controls (including publish button) for all users on curriculum pages, unit pages, and PL lesson pages. This PR fixes that regression by restoring access to the admin controls for authors while continuing to hide them for partners.

## Testing story

The original PR contained unit tests. This PR does not contain tests because the fix is needed somewhat urgently by the PL team. similar unit tests will be added in the next PR. For now, I have manually verified that the Publish button has appeared locally on curriculum and unit pages whereas it is not visible on the same pages in production.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
