### PR TITLE
add unit tests for admin menu, and omit more controls

### DIFF
--- a/curricula/templates/curricula/hoc_lesson.html
+++ b/curricula/templates/curricula/hoc_lesson.html
@@ -125,15 +125,15 @@
                     <button class="btn btn-primary" id="clone_this" data-pk="{{ lesson.pk }}" data-type="Lesson">Clone</button><i id="clone_spinner"></i><br/>
                     <pre id="clone_results"></pre>
                 </div>
+                <div class="drawer-body">
+                    <h2>Code Studio</h2>
+                    <button class="btn btn-primary" id="get_stage_details" data-pk="{{ lesson.pk }}" data-type="Lesson">
+                        Get Code Studio Stage Details
+                    </button>
+                    <i id="stage_progress_spinner"></i>
+                    <pre id="stage_details_results"></pre>
+                </div>
             {% endif %}
-            <div class="drawer-body">
-                <h2>Code Studio</h2>
-                <button class="btn btn-primary" id="get_stage_details" data-pk="{{ lesson.pk }}" data-type="Lesson">
-                    Get Code Studio Stage Details
-                </button>
-                <i id="stage_progress_spinner"></i>
-                <pre id="stage_details_results"></pre>
-            </div>
             <div class="drawer-body">
                 <h2>Resources</h2>
                 <ul>

--- a/curricula/templates/curricula/partials/admin_menu.html
+++ b/curricula/templates/curricula/partials/admin_menu.html
@@ -41,14 +41,14 @@
                 <i id="clone_spinner"></i><br/>
                 {% comment %} ToDo: add ability to clone into a different parent {% endcomment %}
                 <pre id="clone_results"></pre>
-            {% endif %}
 
-            <h2>Code Studio</h2>
-            <button class="btn btn-primary" id="get_stage_details" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">
-                Get Code Studio Stage Details
-            </button>
-            <i id="stage_progress_spinner"></i>
-            <pre id="stage_details_results"></pre>
+                <h2>Code Studio</h2>
+                <button class="btn btn-primary" id="get_stage_details" data-pk="{{ page.pk }}" data-type="{{ pagetype }}">
+                    Get Code Studio Stage Details
+                </button>
+                <i id="stage_progress_spinner"></i>
+                <pre id="stage_details_results"></pre>
+            {% endif %}
 
             {% if pagetype == "Lesson" %}
             <h2>Resources</h2>

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -91,10 +91,8 @@ class CurriculaRenderingTestCase(TestCase):
         self.assert_admin_menu('/test-curriculum/test-unit/1/', False)
         self.assert_admin_menu('/test-curriculum/hoc-unit/1/', False)
 
-        permission = Permission.objects.get(codename='change_lesson')
-        self.user.user_permissions.add(permission)
-        permission = Permission.objects.get(codename='access_all_lessons')
-        self.user.user_permissions.add(permission)
+        self.add_permission(self.user, 'change_lesson')
+        self.add_permission(self.user, 'access_all_lessons')
 
         # Copy button appears in admin menu for users with sufficient permissions
         self.assert_admin_menu('/test-curriculum/test-unit/1/', True)
@@ -109,6 +107,9 @@ class CurriculaRenderingTestCase(TestCase):
         else:
             self.assertNotIn('deepSpaceCopy', response.content)
 
+    def add_permission(self, user, codename):
+        permission = Permission.objects.get(codename=codename)
+        user.user_permissions.add(permission)
 
     def test_render_lesson_with_levels(self):
         stage = {

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -91,6 +91,9 @@ class CurriculaRenderingTestCase(TestCase):
         self.assert_admin_menu('/test-curriculum/', False)
         self.assert_admin_menu('/pl-curriculum/', False)
 
+        # Supply one combination of permissions which give the user access
+        # to the admin controls in this menu. Other combinations, such as
+        # when a partner views a page they own, are not covered by this test.
         self.add_permission(self.user, 'change_curriculum')
         self.add_permission(self.user, 'access_all_curricula')
 
@@ -102,6 +105,9 @@ class CurriculaRenderingTestCase(TestCase):
         self.assert_admin_menu('/test-curriculum/test-unit/', False)
         self.assert_admin_menu('/pl-curriculum/pl-unit/', False)
 
+        # Supply one combination of permissions which give the user access
+        # to the admin controls in this menu. Other combinations, such as
+        # when a partner views a page they own, are not covered by this test.
         self.add_permission(self.user, 'change_unit')
         self.add_permission(self.user, 'access_all_units')
 
@@ -114,6 +120,9 @@ class CurriculaRenderingTestCase(TestCase):
         self.assert_admin_menu('/test-curriculum/hoc-unit/1/', False)
         self.assert_admin_menu('/pl-curriculum/pl-unit/1/', False)
 
+        # Supply one combination of permissions which give the user access
+        # to the admin controls in this menu. Other combinations, such as
+        # when a partner views a page they own, are not covered by this test.
         self.add_permission(self.user, 'change_lesson')
         self.add_permission(self.user, 'access_all_lessons')
 

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -88,14 +88,8 @@ class CurriculaRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_lesson_admin_menu(self):
-        response = self.client.get('/test-curriculum/test-unit/1/')
-        self.assertEqual(response.status_code, 200)
-        self.assertIn('admin_edit', response.content)
-        self.assertNotIn('deepSpaceCopy', response.content)
-        response = self.client.get('/test-curriculum/hoc-unit/1/')
-        self.assertEqual(response.status_code, 200)
-        self.assertIn('admin_edit', response.content)
-        self.assertNotIn('deepSpaceCopy', response.content)
+        self.assert_admin_menu('/test-curriculum/test-unit/1/', False)
+        self.assert_admin_menu('/test-curriculum/hoc-unit/1/', False)
 
         permission = Permission.objects.get(codename='change_lesson')
         self.user.user_permissions.add(permission)
@@ -103,14 +97,18 @@ class CurriculaRenderingTestCase(TestCase):
         self.user.user_permissions.add(permission)
 
         # Copy button appears in admin menu for users with sufficient permissions
-        response = self.client.get('/test-curriculum/test-unit/1/')
+        self.assert_admin_menu('/test-curriculum/test-unit/1/', True)
+        self.assert_admin_menu('/test-curriculum/hoc-unit/1/', True)
+
+    def assert_admin_menu(self, path, with_copy_button):
+        response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertIn('admin_edit', response.content)
-        self.assertIn('deepSpaceCopy', response.content)
-        response = self.client.get('/test-curriculum/hoc-unit/1/')
-        self.assertEqual(response.status_code, 200)
-        self.assertIn('admin_edit', response.content)
-        self.assertIn('deepSpaceCopy', response.content)
+        if with_copy_button:
+            self.assertIn('deepSpaceCopy', response.content)
+        else:
+            self.assertNotIn('deepSpaceCopy', response.content)
+
 
     def test_render_lesson_with_levels(self):
         stage = {

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -122,14 +122,16 @@ class CurriculaRenderingTestCase(TestCase):
         self.assert_admin_menu('/test-curriculum/hoc-unit/1/', True)
         self.assert_admin_menu('/pl-curriculum/pl-unit/1/', True)
 
-    def assert_admin_menu(self, path, with_copy_button):
+    def assert_admin_menu(self, path, with_admin_controls):
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertIn('admin_edit', response.content)
-        if with_copy_button:
+        if with_admin_controls:
             self.assertIn('deepSpaceCopy', response.content)
+            self.assertIn('Get Code Studio Stage Details', response.content)
         else:
             self.assertNotIn('deepSpaceCopy', response.content)
+            self.assertNotIn('Get Code Studio Stage Details', response.content)
 
     def add_permission(self, user, codename):
         permission = Permission.objects.get(codename=codename)

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -87,9 +87,32 @@ class CurriculaRenderingTestCase(TestCase):
         response = self.client.get('/pl-curriculum/pl-unit/1/')
         self.assertEqual(response.status_code, 200)
 
-    def test_lesson_admin_menu(self):
+    def test_render_curriculum_admin_menu(self):
+        self.assert_admin_menu('/test-curriculum/', False)
+        self.assert_admin_menu('/pl-curriculum/', False)
+
+        self.add_permission(self.user, 'change_curriculum')
+        self.add_permission(self.user, 'access_all_curricula')
+
+        # Copy button appears in admin menu for users with sufficient permissions
+        self.assert_admin_menu('/test-curriculum/', True)
+        self.assert_admin_menu('/pl-curriculum/', True)
+
+    def test_render_unit_admin_menu(self):
+        self.assert_admin_menu('/test-curriculum/test-unit/', False)
+        self.assert_admin_menu('/pl-curriculum/pl-unit/', False)
+
+        self.add_permission(self.user, 'change_unit')
+        self.add_permission(self.user, 'access_all_units')
+
+        # Copy button appears in admin menu for users with sufficient permissions
+        self.assert_admin_menu('/test-curriculum/test-unit/', True)
+        self.assert_admin_menu('/pl-curriculum/pl-unit/', True)
+
+    def test_render_lesson_admin_menu(self):
         self.assert_admin_menu('/test-curriculum/test-unit/1/', False)
         self.assert_admin_menu('/test-curriculum/hoc-unit/1/', False)
+        self.assert_admin_menu('/pl-curriculum/pl-unit/1/', False)
 
         self.add_permission(self.user, 'change_lesson')
         self.add_permission(self.user, 'access_all_lessons')
@@ -97,6 +120,7 @@ class CurriculaRenderingTestCase(TestCase):
         # Copy button appears in admin menu for users with sufficient permissions
         self.assert_admin_menu('/test-curriculum/test-unit/1/', True)
         self.assert_admin_menu('/test-curriculum/hoc-unit/1/', True)
+        self.assert_admin_menu('/pl-curriculum/pl-unit/1/', True)
 
     def assert_admin_menu(self, path, with_copy_button):
         response = self.client.get(path)


### PR DESCRIPTION
# Description

Follow-on to https://github.com/code-dot-org/curriculumbuilder/pull/195, which was merged without tests to unblock the PL team. This PR extracts some test helpers and adds test cases to cover the code changes in #195 . 

update: this PR also omits Get Code Studio Stage Details from the menu for users who do not have permission to edit the page.

## Testing story

Adds unit test cases for each unique way that we render the admin menu.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
