### PR TITLE
upgrade psycopg2 to avoid build warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Only follow these steps if you are on Ubuntu / Linux.
 
 1. install Ubuntu dependencies
 ```
-sudo apt-get install python-pip postgresql wkhtmltopdf libcurl4-openssl-dev libssl-dev
+sudo apt-get install python-pip postgresql wkhtmltopdf libcurl4-openssl-dev libssl-dev libpq-dev
 sudo snap install --classic heroku
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ newrelic==2.96.0.80
 oauthlib==1.0.3
 pdfkit==0.5.0
 plotly==1.9.3
-psycopg2==2.7.4
+psycopg2-binary==2.8.4
 pycurl==7.43.0.3
 pyPdf==1.13
 pytz==2015.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ newrelic==2.96.0.80
 oauthlib==1.0.3
 pdfkit==0.5.0
 plotly==1.9.3
-psycopg2-binary==2.8.4
+psycopg2==2.8.4
 pycurl==7.43.0.3
 pyPdf==1.13
 pytz==2015.7


### PR DESCRIPTION
# Description

Eliminates the following warning when building and running curriculumbuilder:

> /app/.heroku/python/lib/python2.7/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.


## Testing story

In addition to running existing unit tests, I've made sure the server can be run and accessed locally on both Mac and Linux.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
