### PR TITLE
remove 'object' from the list of tags allowed in markdown

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -427,9 +427,9 @@ RICHTEXT_ALLOWED_TAGS = (
     'br', 'button', 'caption', 'center', 'cite', 'code', 'col', 'colgroup', 'dd', 'del', 'dfn',
     'dir', 'div', 'display', 'dl', 'dt', 'em', 'fieldset', 'figure', 'font', 'footer', 'form', 'h1',
     'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'i', 'iframe', 'img', 'input', 'ins', 'kbd',
-    'label', 'legend', 'li', 'map', 'men', 'nav', 'object', 'ol', 'optgroup', 'option', 'p', 'pre',
-    'q', 's', 'samp', 'section', 'select', 'small', 'span', 'strike', 'strong', 'sub', 'sup',
-    'table', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr', 'tt', '', 'ul', 'var', 'wbr',
+    'label', 'legend', 'li', 'map', 'men', 'nav', 'ol', 'optgroup', 'option', 'p', 'pre', 'q', 's',
+    'samp', 'section', 'select', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'table',
+    'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead', 'tr', 'tt', '', 'ul', 'var', 'wbr',
     'summary', 'details'
 )
 RICHTEXT_ALLOWED_STYLES = (

--- a/curriculumBuilder/tests/test_richtext.py
+++ b/curriculumBuilder/tests/test_richtext.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+
+from mezzanine.core.templatetags.mezzanine_tags import richtext_filters
+
+class RichtextTestCase(TestCase):
+    """
+    Test our markdown rendering procedures
+    """
+
+    def test_disallow_object_tag(self):
+        """
+        we want to prevent translators from adding translations that embed unwanted content via
+        object tags, so we disallow the use of those tags in markdown sitewide.
+        """
+        richtext = "<object type=\"application/pdf\" data=\"/media/examples/In-CC0.pdf\" width=\"250\" height=\"200\"></object>"
+        self.assertEqual("<p></p>", richtext_filters(richtext))


### PR DESCRIPTION
# Description

To prevent translators from embedding unwanted content using those tags.

To verify that this won't break any existing content, I:

1. set
   
   ```
   JACKFROST_STORAGE = 'jackfrost.defaults.JackfrostFilesStorage'
   ```
   
   in `local_settings.py`

2. ran

   ```python
   from curricula.models import Curriculum

   for curriculum in Curriculum.objects.all():
     if curriculum.jackfrost_can_build():
       list(curriculum.publish(True))
   ```

3. used `grep -Ro "<object" __jackfrost` to find all examples of `<object>` tags in content
4. verified that only [`csf-18/index.hml`](https://www.codecurricula.com/csf-18/) was using an object tag, and that was to embed https://code.org/curriculum/docs/csf/CSF_Curriculum_Guide_2018_smaller.pdf on the page
5. with assistance from Mike and Arron, updated the page to instead embed https://docs.google.com/document/d/1BqrcK3fD9VNy8IMWbkNevSZIW11CbSs7-dduiymH_a0/preview using the same pattern we use for csf-19