### PR TITLE
Add unit tests for unit and curriculum edit pages

### DIFF
--- a/curricula/tests/test_curricula_admin.py
+++ b/curricula/tests/test_curricula_admin.py
@@ -32,7 +32,7 @@ class CurriculaAdminTestCase(TestCase):
         self.assertNotIn('Ancestor', response.content, 'privileged field should not be visible')
         self.assertNotIn('Show in menus', response.content, 'privileged field should not be visible')
 
-        permission = Permission.objects.get(codename='access_all_resources')
+        permission = Permission.objects.get(codename='access_all_curricula')
         self.user.user_permissions.add(permission)
 
         response = self.client.get('/admin/curricula/curriculum/add/')
@@ -52,7 +52,7 @@ class CurriculaAdminTestCase(TestCase):
         self.assertNotIn('Forum url', response.content, 'privileged field should not be visible')
         self.assertNotIn('Show in menus', response.content, 'privileged field should not be visible')
 
-        permission = Permission.objects.get(codename='access_all_lessons')
+        permission = Permission.objects.get(codename='access_all_units')
         self.user.user_permissions.add(permission)
 
         response = self.client.get('/admin/curricula/unit/add/')

--- a/curricula/tests/test_curricula_admin.py
+++ b/curricula/tests/test_curricula_admin.py
@@ -29,7 +29,7 @@ class CurriculaAdminTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('Add curriculum', response.content)
         self.assertIn('Frameworks', response.content)
-        self.assertNotIn('Ancestor', response.content, 'privileged field should be visible')
+        self.assertNotIn('Ancestor', response.content, 'privileged field should not be visible')
         self.assertNotIn('Show in menus', response.content, 'privileged field should not be visible')
 
         permission = Permission.objects.get(codename='access_all_resources')
@@ -49,7 +49,7 @@ class CurriculaAdminTestCase(TestCase):
         response = self.client.get('/admin/curricula/unit/add/')
         self.assertEqual(response.status_code, 200)
         self.assertIn('Add unit', response.content)
-        self.assertNotIn('Ancestor', response.content, 'privileged field should be visible')
+        self.assertNotIn('Ancestor', response.content, 'privileged field should not be visible')
         self.assertNotIn('Show in menus', response.content, 'privileged field should not be visible')
 
         permission = Permission.objects.get(codename='access_all_lessons')

--- a/curricula/tests/test_curricula_admin.py
+++ b/curricula/tests/test_curricula_admin.py
@@ -27,7 +27,7 @@ class CurriculaAdminTestCase(TestCase):
 
         response = self.client.get('/admin/curricula/curriculum/add/')
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Change curriculum', response.content)
+        self.assertIn('Add curriculum', response.content)
         self.assertIn('Frameworks', response.content)
         self.assertNotIn('Ancestor', response.content, 'privileged field should be visible')
         self.assertNotIn('Show in menus', response.content, 'privileged field should not be visible')
@@ -37,7 +37,7 @@ class CurriculaAdminTestCase(TestCase):
 
         response = self.client.get('/admin/curricula/curriculum/add/')
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Change curriculum', response.content)
+        self.assertIn('Add curriculum', response.content)
         self.assertIn('Frameworks', response.content)
         self.assertIn('Ancestor', response.content, 'privileged field should be visible')
         self.assertIn('Show in menus', response.content, 'privileged field should be visible')
@@ -48,7 +48,7 @@ class CurriculaAdminTestCase(TestCase):
 
         response = self.client.get('/admin/curricula/unit/add/')
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Change unit', response.content)
+        self.assertIn('Add unit', response.content)
         self.assertNotIn('Ancestor', response.content, 'privileged field should be visible')
         self.assertNotIn('Show in menus', response.content, 'privileged field should not be visible')
 
@@ -57,6 +57,6 @@ class CurriculaAdminTestCase(TestCase):
 
         response = self.client.get('/admin/curricula/unit/add/')
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Change unit', response.content)
+        self.assertIn('Add unit', response.content)
         self.assertIn('Ancestor', response.content, 'privileged field should be visible')
         self.assertIn('Show in menus', response.content, 'privileged field should be visible')

--- a/curricula/tests/test_curricula_admin.py
+++ b/curricula/tests/test_curricula_admin.py
@@ -49,7 +49,7 @@ class CurriculaAdminTestCase(TestCase):
         response = self.client.get('/admin/curricula/unit/add/')
         self.assertEqual(response.status_code, 200)
         self.assertIn('Add unit', response.content)
-        self.assertNotIn('Ancestor', response.content, 'privileged field should not be visible')
+        self.assertNotIn('Forum url', response.content, 'privileged field should not be visible')
         self.assertNotIn('Show in menus', response.content, 'privileged field should not be visible')
 
         permission = Permission.objects.get(codename='access_all_lessons')
@@ -58,5 +58,5 @@ class CurriculaAdminTestCase(TestCase):
         response = self.client.get('/admin/curricula/unit/add/')
         self.assertEqual(response.status_code, 200)
         self.assertIn('Add unit', response.content)
-        self.assertIn('Ancestor', response.content, 'privileged field should be visible')
+        self.assertIn('Forum url', response.content, 'privileged field should be visible')
         self.assertIn('Show in menus', response.content, 'privileged field should be visible')

--- a/lessons/tests/test_curricula_admin.py
+++ b/lessons/tests/test_curricula_admin.py
@@ -1,0 +1,62 @@
+from django.test import TestCase
+from django.contrib.auth.models import Permission
+from django.contrib.sites.models import Site
+
+from mezzanine.core.models import SitePermission
+
+from curricula.factories import UserFactory
+
+
+# Tests for admin pages in lessons/admin.py
+class CurriculaAdminTestCase(TestCase):
+
+    def setUp(self):
+        user = UserFactory()
+        user.is_staff = True
+        user.save()
+        self.user = user
+        self.assertTrue(self.client.login(username=user.username, password='password'))
+
+        site = Site.objects.first()
+        siteperms = SitePermission.objects.create(user=user)
+        siteperms.sites.add(site)
+
+    def test_render_add_curriculum(self):
+        permission = Permission.objects.get(codename='add_curriculum')
+        self.user.user_permissions.add(permission)
+
+        response = self.client.get('/admin/curricula/curriculum/add/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Change curriculum', response.content)
+        self.assertIn('Frameworks', response.content)
+        self.assertNotIn('Ancestor', response.content, 'privileged field should be visible')
+        self.assertNotIn('Show in menus', response.content, 'privileged field should not be visible')
+
+        permission = Permission.objects.get(codename='access_all_resources')
+        self.user.user_permissions.add(permission)
+
+        response = self.client.get('/admin/curricula/curriculum/add/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Change curriculum', response.content)
+        self.assertIn('Frameworks', response.content)
+        self.assertIn('Ancestor', response.content, 'privileged field should be visible')
+        self.assertIn('Show in menus', response.content, 'privileged field should be visible')
+
+    def test_render_add_unit(self):
+        permission = Permission.objects.get(codename='add_unit')
+        self.user.user_permissions.add(permission)
+
+        response = self.client.get('/admin/curricula/unit/add/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Change unit', response.content)
+        self.assertNotIn('Ancestor', response.content, 'privileged field should be visible')
+        self.assertNotIn('Show in menus', response.content, 'privileged field should not be visible')
+
+        permission = Permission.objects.get(codename='access_all_lessons')
+        self.user.user_permissions.add(permission)
+
+        response = self.client.get('/admin/curricula/unit/add/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Change unit', response.content)
+        self.assertIn('Ancestor', response.content, 'privileged field should be visible')
+        self.assertIn('Show in menus', response.content, 'privileged field should be visible')


### PR DESCRIPTION
# Description

Limited so fields of the edit page for external accounts in this PR: https://github.com/code-dot-org/curriculumbuilder/pull/194/. This is the follow-up work to add the tests for that.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
