### PR TITLE
Hide add resource button unless you are a superuser

### DIFF
--- a/curricula/templates/curricula/partials/hoc_lesson_front.html
+++ b/curricula/templates/curricula/partials/hoc_lesson_front.html
@@ -127,7 +127,7 @@
                 {% endfor %}
             {% endwith %}
         {% endif %}
-        {% if user.is_staff %}
+        {% if user.is_superuser %}
             <a href="/admin/lessons/lesson_resources/add/?lesson={{ lesson.pk }}" target="_blank">Add a
                 resource</a>{% endif %}
 

--- a/curricula/templates/curricula/partials/lesson_front.html
+++ b/curricula/templates/curricula/partials/lesson_front.html
@@ -143,7 +143,7 @@
                 {% endwith %}
             {% endwith %}
         {% endif %}
-        {% if user.is_staff %}
+        {% if user.is_superuser %}
             <a href="/admin/lessons/lesson_resources/add/?lesson={{ lesson.pk }}" target="_blank">Add a
                 resource</a>{% endif %}
 

--- a/curricula/templates/curricula/partials/pl_lesson_front.html
+++ b/curricula/templates/curricula/partials/pl_lesson_front.html
@@ -93,7 +93,7 @@
         {% endif %}
     {% endcomment %}
 
-        {% if user.is_staff %}
+        {% if user.is_superuser %}
             <a href="/admin/lessons/lesson_resources/add/?lesson={{ lesson.pk }}" target="_blank">Add a
                 resource</a>{% endif %}
     </div>


### PR DESCRIPTION
# Description

Hide the Add Resource Button on Lesson Front End unless you are a superuser since only superusers have permissions to see the page that link takes you to.

| Superuser | Non-Superuser |
| --- | --- |
| ![Screen Shot 2019-11-22 at 3 00 52 PM](https://user-images.githubusercontent.com/208083/69456592-0700a080-0d39-11ea-808f-fd38e1887831.png) | ![Screen Shot 2019-11-22 at 3 01 19 PM](https://user-images.githubusercontent.com/208083/69456590-06680a00-0d39-11ea-96cc-8a42b43c25e0.png) |




## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-894)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
