### PR TITLE
Use docs/concepts instead of just concepts

### DIFF
--- a/curricula/urls.py
+++ b/curricula/urls.py
@@ -9,7 +9,7 @@ urlpatterns = patterns('curricula.views',
 
                        # Allow viewing concept documentations without the /documentation/ prefix
                        # so links work on both curriculumbuilder and docs.code.org
-                       url(r'^(?P<slug>concepts.*)/$', documentation_views.map_view, name="map_view"),
+                       url(r'^(?P<slug>/docs/concepts.*)/$', documentation_views.map_view, name="map_view"),
 
                        # Ajax endpoints
                        # Todo: fix Page history view


### PR DESCRIPTION
# Description

Issue: 
- Go to : https://studio.code.org/s/csd4-2019/stage/12/puzzle/13
- Go to help and tips tab
- Click on Design Mode
- In pop up right click on one of the things in the left nav bar
- Page gives error
- In url add `docs/` in front on concepts
- No more page error

I think this is the fix to fix the code studio problem described above but I don't know of any way to confirm that it works without just shipping it.  Thoughts?

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-910)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
