### PR TITLE
Doc url

### DIFF
--- a/curricula/urls.py
+++ b/curricula/urls.py
@@ -9,7 +9,7 @@ urlpatterns = patterns('curricula.views',
 
                        # Allow viewing concept documentations without the /documentation/ prefix
                        # so links work on both curriculumbuilder and docs.code.org
-                       url(r'^(?P<slug>/docs/concepts.*)/$', documentation_views.map_view, name="map_view"),
+                       url(r'^(?P<slug>/concepts.*)/$', documentation_views.map_view, name="map_view"),
 
                        # Ajax endpoints
                        # Todo: fix Page history view

--- a/documentation/factories.py
+++ b/documentation/factories.py
@@ -1,0 +1,11 @@
+from factory import Sequence
+from factory.django import DjangoModelFactory
+
+from documentation.models import Map
+
+class MapFactory(DjangoModelFactory):
+    class Meta:
+        model = Map
+
+    title = Sequence(lambda n: "Concept %03d" % n)
+    slug = Sequence(lambda n: "/concepts/%03d" % n)

--- a/documentation/models.py
+++ b/documentation/models.py
@@ -306,6 +306,12 @@ class Map(Page, RichText, CloneableMixin):
     def overridden(self):
         return False
 
+    def get_children(self):
+        return Map.objects.filter(parent=self).all()
+
+    def get_absolute_url(self):
+        return '/docs/%s/' % self.slug
+
     def get_published_url(self):
         return '//docs.code.org%s' % self.get_absolute_url()
 

--- a/documentation/models.py
+++ b/documentation/models.py
@@ -306,6 +306,7 @@ class Map(Page, RichText, CloneableMixin):
     def overridden(self):
         return False
 
+    # Returns Map instead of Page so that we can use get_absolute_url to get the correct link
     def get_children(self):
         return Map.objects.filter(parent=self).all()
 

--- a/documentation/templates/documentation/partials/map_menu.html
+++ b/documentation/templates/documentation/partials/map_menu.html
@@ -3,8 +3,8 @@
     {% if m.list|length > 0 %}
     <ul>
         {% for sub in m.list %}
-            <li><a href="{{ sub.get_absolute_url }}">{{ sub.title }}</a></li>
-            {% regroup sub.children.all by parent as sub_menu %}
+            <li><a href="{{ sub.get_published_url }}">{{ sub.title }}</a></li>
+            {% regroup sub.get_children by parent as sub_menu %}
             {% include "documentation/partials/map_menu.html" with map_menu=sub_menu %}
         {% endfor %}
     </ul>

--- a/documentation/templates/documentation/partials/map_menu.html
+++ b/documentation/templates/documentation/partials/map_menu.html
@@ -3,7 +3,7 @@
     {% if m.list|length > 0 %}
     <ul>
         {% for sub in m.list %}
-            <li><a href="{{ sub.get_published_url }}">{{ sub.title }}</a></li>
+            <li><a href="{{ sub.get_absolute_url }}">{{ sub.title }}</a></li>
             {% regroup sub.get_children by parent as sub_menu %}
             {% include "documentation/partials/map_menu.html" with map_menu=sub_menu %}
         {% endfor %}

--- a/documentation/tests.py
+++ b/documentation/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/documentation/tests/test_map_model.py
+++ b/documentation/tests/test_map_model.py
@@ -6,11 +6,12 @@ from documentation.factories import MapFactory
 class MapModelTestCase(TestCase):
 
     def setUp(self):
-        self.myMap = MapFactory(title='my concept', slug='concepts/myConcept')
-        self.myChildMap = MapFactory(title='my concept', slug='concepts/myConcept', parent=self.myMap)
+        self.myMap = MapFactory(title='my concept parent', slug='concepts/myConcept')
+        self.myChildMap = MapFactory(title='my concept child', slug='concepts/myConcept/childConcept', parent=self.myMap)
 
     def test_get_absolute_url(self):
         self.assertEqual('/docs/concepts/myConcept/', self.myMap.get_absolute_url())
+        self.assertEqual('/docs/concepts/myConcept/childConcept/', self.myChildMap.get_absolute_url())
 
     def test_get_children(self):
         self.assertIn(self.myChildMap, self.myMap.get_children())

--- a/documentation/tests/test_map_model.py
+++ b/documentation/tests/test_map_model.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+
+from documentation.factories import MapFactory
+
+# Tests for admin pages in lessons/admin.py
+class MapModelTestCase(TestCase):
+
+    def setUp(self):
+        self.myMap = MapFactory(title='my concept', slug='concepts/myConcept')
+        self.myChildMap = MapFactory(title='my concept', slug='concepts/myConcept', parent=self.myMap)
+
+    def test_get_absolute_url(self):
+        self.assertEqual('/docs/concepts/myConcept/', self.myMap.get_absolute_url())
+
+    def test_get_children(self):
+        self.assertIn(self.myChildMap, self.myMap.get_children())


### PR DESCRIPTION
# Description

Issue: 
- Go to : https://studio.code.org/s/csd4-2019/stage/12/puzzle/13
- Go to help and tips tab
- Click on Design Mode
- In pop up right click on one of the things in the left nav bar
- Page gives error
- In url add `docs/` in front on concepts
- No more page error

Previous attempt to fix which did not work: https://github.com/code-dot-org/curriculumbuilder/pull/203  (This PR reverts that change). 

This fixes the issue by changing the result of `get_absolute_url` for the maps to include `/docs`.

You can see the url is generating correctly in these screenshots (at the bottom right corner)

<img width="1440" alt="Screen Shot 2019-12-06 at 10 02 39 AM" src="https://user-images.githubusercontent.com/208083/70332614-01628a80-1810-11ea-9523-e0c6f9639707.png">
<img width="1440" alt="Screen Shot 2019-12-06 at 10 02 37 AM" src="https://user-images.githubusercontent.com/208083/70332615-01628a80-1810-11ea-9535-c01554cab876.png">
<img width="1440" alt="Screen Shot 2019-12-06 at 10 02 34 AM" src="https://user-images.githubusercontent.com/208083/70332616-01628a80-1810-11ea-9d02-f751480b27bd.png">


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-910)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

I added unit tests for `get_absolute_url` and `get_children` for the Map Model.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
