### PR TITLE
Give a different url depending on the host

### DIFF
--- a/documentation/models.py
+++ b/documentation/models.py
@@ -310,9 +310,11 @@ class Map(Page, RichText, CloneableMixin):
     def get_children(self):
         return Map.objects.filter(parent=self).all()
 
+    # If you are on curriculum.code.org you need /documentation at the start of a map url
     def get_absolute_url_for_curriculum_code_org_map_menu(self):
         return '/documentation/%s/' % self.slug
 
+    # If you are on studio.code.org you need /docs at the start of a map url
     def get_absolute_url_for_studio_code_org_map_menu(self):
         return '/docs/%s/' % self.slug
 

--- a/documentation/models.py
+++ b/documentation/models.py
@@ -310,7 +310,10 @@ class Map(Page, RichText, CloneableMixin):
     def get_children(self):
         return Map.objects.filter(parent=self).all()
 
-    def get_absolute_url(self):
+    def get_absolute_url_for_curriculum_code_org_map_menu(self):
+        return '/documentation/%s/' % self.slug
+
+    def get_absolute_url_for_studio_code_org_map_menu(self):
         return '/docs/%s/' % self.slug
 
     def get_published_url(self):

--- a/documentation/models.py
+++ b/documentation/models.py
@@ -310,14 +310,6 @@ class Map(Page, RichText, CloneableMixin):
     def get_children(self):
         return Map.objects.filter(parent=self).all()
 
-    # If you are on curriculum.code.org you need /documentation at the start of a map url
-    def get_absolute_url_for_curriculum_code_org_map_menu(self):
-        return '/documentation/%s/' % self.slug
-
-    # If you are on studio.code.org you need /docs at the start of a map url
-    def get_absolute_url_for_studio_code_org_map_menu(self):
-        return '/docs/%s/' % self.slug
-
     def get_published_url(self):
         return '//docs.code.org%s' % self.get_absolute_url()
 

--- a/documentation/templates/documentation/partials/map_menu.html
+++ b/documentation/templates/documentation/partials/map_menu.html
@@ -3,7 +3,12 @@
     {% if m.list|length > 0 %}
     <ul>
         {% for sub in m.list %}
-            <li><a href="{{ sub.get_absolute_url }}">{{ sub.title }}</a></li>
+            {% if request.get_host == 'curriculum.code.org' or request.get_host == 'localhost:8000' %}
+                <li><a href="{{ sub.get_absolute_url_for_curriculum_code_org_map_menu }}">{{ sub.title }}</a></li>
+            {% endif %}
+            {% if request.get_host == 'studio.code.org' %}
+                <li><a href="{{ sub.get_absolute_url_for_studio_code_org_map_menu }}">{{ sub.title }}</a></li>
+            {% endif %}
             {% regroup sub.get_children by parent as sub_menu %}
             {% include "documentation/partials/map_menu.html" with map_menu=sub_menu %}
         {% endfor %}

--- a/documentation/templates/documentation/partials/map_menu.html
+++ b/documentation/templates/documentation/partials/map_menu.html
@@ -1,14 +1,10 @@
+{% load documentation_extras %}
 
 {% for m in map_menu %}
     {% if m.list|length > 0 %}
     <ul>
         {% for sub in m.list %}
-            {% if request.get_host == 'curriculum.code.org' or request.get_host == 'localhost:8000' %}
-                <li><a href="{{ sub.get_absolute_url_for_curriculum_code_org_map_menu }}">{{ sub.title }}</a></li>
-            {% endif %}
-            {% if request.get_host == 'studio.code.org' %}
-                <li><a href="{{ sub.get_absolute_url_for_studio_code_org_map_menu }}">{{ sub.title }}</a></li>
-            {% endif %}
+            <li><a href="{{ sub|get_absolute_url_for_host:request.get_host }}">{{ sub.title }}</a></li>
             {% regroup sub.get_children by parent as sub_menu %}
             {% include "documentation/partials/map_menu.html" with map_menu=sub_menu %}
         {% endfor %}

--- a/documentation/templatetags/documentation_extras.py
+++ b/documentation/templatetags/documentation_extras.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def get_absolute_url_for_host(map, host):
+    if host == 'curriculum.code.org' or host == 'localhost:8000':
+        return '/documentation/%s/' % map.slug
+    elif host == 'studio.code.org':
+        return '/docs/%s/' % map.slug

--- a/documentation/tests/test_map_model.py
+++ b/documentation/tests/test_map_model.py
@@ -9,13 +9,5 @@ class MapModelTestCase(TestCase):
         self.myMap = MapFactory(title='my concept parent', slug='concepts/myConcept')
         self.myChildMap = MapFactory(title='my concept child', slug='concepts/myConcept/childConcept', parent=self.myMap)
 
-    def test_get_absolute_url_for_curriculum_code_org_map_menu(self):
-        self.assertEqual('/documentation/concepts/myConcept/', self.myMap.get_absolute_url_for_curriculum_code_org_map_menu())
-        self.assertEqual('/documentation/concepts/myConcept/childConcept/', self.myChildMap.get_absolute_url_for_curriculum_code_org_map_menu())
-
-    def test_get_absolute_url_for_studio_code_org_map_menu(self):
-        self.assertEqual('/docs/concepts/myConcept/', self.myMap.get_absolute_url_for_studio_code_org_map_menu())
-        self.assertEqual('/docs/concepts/myConcept/childConcept/', self.myChildMap.get_absolute_url_for_studio_code_org_map_menu())
-
     def test_get_children(self):
         self.assertIn(self.myChildMap, self.myMap.get_children())

--- a/documentation/tests/test_map_model.py
+++ b/documentation/tests/test_map_model.py
@@ -2,7 +2,8 @@ from django.test import TestCase
 
 from documentation.factories import MapFactory
 
-# Tests for admin pages in lessons/admin.py
+from documentation.templatetags.documentation_extras import get_absolute_url_for_host
+
 class MapModelTestCase(TestCase):
 
     def setUp(self):
@@ -11,3 +12,9 @@ class MapModelTestCase(TestCase):
 
     def test_get_children(self):
         self.assertIn(self.myChildMap, self.myMap.get_children())
+
+    def test_get_absolute_url_for_host(self):
+        result = get_absolute_url_for_host(self.myMap, 'curriculum.code.org')
+        self.assertEqual(result, '/documentation/concepts/myConcept/')
+        result2 = get_absolute_url_for_host(self.myMap, 'studio.code.org')
+        self.assertEqual(result2, '/docs/concepts/myConcept/')

--- a/documentation/tests/test_map_model.py
+++ b/documentation/tests/test_map_model.py
@@ -9,9 +9,13 @@ class MapModelTestCase(TestCase):
         self.myMap = MapFactory(title='my concept parent', slug='concepts/myConcept')
         self.myChildMap = MapFactory(title='my concept child', slug='concepts/myConcept/childConcept', parent=self.myMap)
 
-    def test_get_absolute_url(self):
-        self.assertEqual('/docs/concepts/myConcept/', self.myMap.get_absolute_url())
-        self.assertEqual('/docs/concepts/myConcept/childConcept/', self.myChildMap.get_absolute_url())
+    def test_get_absolute_url_for_curriculum_code_org_map_menu(self):
+        self.assertEqual('/documentation/concepts/myConcept/', self.myMap.get_absolute_url_for_curriculum_code_org_map_menu())
+        self.assertEqual('/documentation/concepts/myConcept/childConcept/', self.myChildMap.get_absolute_url_for_curriculum_code_org_map_menu())
+
+    def test_get_absolute_url_for_studio_code_org_map_menu(self):
+        self.assertEqual('/docs/concepts/myConcept/', self.myMap.get_absolute_url_for_studio_code_org_map_menu())
+        self.assertEqual('/docs/concepts/myConcept/childConcept/', self.myChildMap.get_absolute_url_for_studio_code_org_map_menu())
 
     def test_get_children(self):
         self.assertIn(self.myChildMap, self.myMap.get_children())


### PR DESCRIPTION
# Description

Still trying to solve the same problem explained here: https://github.com/code-dot-org/curriculumbuilder/pull/204

Except now we know curriculum.code.org needs the links to be '/documentation/concepts...' and studio.code.org needs the links to be '/docs/concepts..'

This is definitely a temporary solution and we are tracking the need to clean up all of this here: https://codedotorg.atlassian.net/browse/LP-1072

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-910)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Updated the tests to match the new functions.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
