### PR TITLE
Add testserver as a host

### DIFF
--- a/documentation/templatetags/documentation_extras.py
+++ b/documentation/templatetags/documentation_extras.py
@@ -8,7 +8,7 @@ register = template.Library()
 
 @register.filter
 def get_absolute_url_for_host(map, host):
-    if host == 'curriculum.code.org' or host == 'www.codecurricula.com' or host == 'localhost:8000':
+    if host == 'curriculum.code.org' or host == 'www.codecurricula.com' or host == 'localhost:8000' or host == 'testserver':
         return '/documentation/%s/' % map.slug
     elif host == 'studio.code.org':
         return '/docs/%s/' % map.slug


### PR DESCRIPTION
When I tried to publish a map I got a bunch of no know host errors that said the host was testserver (https://codedotorg.slack.com/archives/C0SUN2VT5/p1576181556149800). Going to add testserver here and see if that fixes things.