### PR TITLE
Use /docs instead of /documentation for links

### DIFF
--- a/curriculumBuilder/urls.py
+++ b/curriculumBuilder/urls.py
@@ -23,8 +23,6 @@ from gong import views as gong_views
 
 from i18n.urls import i18n_patterns_no_default_language_prefix
 
-from .views import redirect_docs
-
 admin.autodiscover()
 
 # Add the urlpatterns for any custom Django applications here.
@@ -110,7 +108,7 @@ urlpatterns += patterns('',
     url(r'^admin_keywords_submit/$', generic_views.admin_keywords_submit, name='admin_keywords_submit'),
     url("^None/$", views.index),  # Dealing with JackFrost bug
     url(r'^docs/', include('documentation.urls', namespace="documentation")),
-    url(r'^documentation/', redirect_docs),
+    url(r'^documentation/', include('documentation.urls', namespace="documentation")),
     url(r'^standards/', include('standards.urls', namespace="standards")),
 )
 

--- a/curriculumBuilder/urls.py
+++ b/curriculumBuilder/urls.py
@@ -107,7 +107,7 @@ urlpatterns += patterns('',
     url(r'^accounts/login/$', 'django.contrib.auth.views.login', {'template_name': 'admin/login.html'}),
     url(r'^admin_keywords_submit/$', generic_views.admin_keywords_submit, name='admin_keywords_submit'),
     url("^None/$", views.index),  # Dealing with JackFrost bug
-    url(r'^documentation/', include('documentation.urls', namespace="documentation")),
+    url(r'^docs/', include('documentation.urls', namespace="documentation")),
     url(r'^standards/', include('standards.urls', namespace="standards")),
 )
 

--- a/curriculumBuilder/urls.py
+++ b/curriculumBuilder/urls.py
@@ -23,6 +23,8 @@ from gong import views as gong_views
 
 from i18n.urls import i18n_patterns_no_default_language_prefix
 
+from .views import redirect_docs
+
 admin.autodiscover()
 
 # Add the urlpatterns for any custom Django applications here.
@@ -108,6 +110,7 @@ urlpatterns += patterns('',
     url(r'^admin_keywords_submit/$', generic_views.admin_keywords_submit, name='admin_keywords_submit'),
     url("^None/$", views.index),  # Dealing with JackFrost bug
     url(r'^docs/', include('documentation.urls', namespace="documentation")),
+    url(r'^documentation/', redirect_docs),
     url(r'^standards/', include('standards.urls', namespace="standards")),
 )
 

--- a/curriculumBuilder/views.py
+++ b/curriculumBuilder/views.py
@@ -1,5 +1,0 @@
-from django.shortcuts import redirect
-
-def redirect_docs(request):
-    response = redirect('/docs/' + request.path.split('/documentation/')[1])
-    return response

--- a/curriculumBuilder/views.py
+++ b/curriculumBuilder/views.py
@@ -1,0 +1,5 @@
+from django.shortcuts import redirect
+
+def redirect_docs(request):
+    response = redirect('/docs/' + request.path.split('/documentation/')[1])
+    return response

--- a/documentation/admin.py
+++ b/documentation/admin.py
@@ -42,9 +42,9 @@ class IDEAdmin(PageAdmin, VersionAdmin):
         }),
     )
 
-    # Override the "view on site" button to use local /documentation/ instead of docs.code.org path
+    # Override the "view on site" button to use local /docs/ instead of docs.code.org path
     def view_on_site(self, obj):
-        return '/documentation%s' % obj.get_absolute_url()
+        return '/docs%s' % obj.get_absolute_url()
 
 
 class BlockForm(ModelForm):
@@ -99,9 +99,9 @@ class BlockAdmin(PageAdmin, VersionAdmin):
         models.CharField: {'widget': Textarea(attrs={'rows': 2})},
     }
 
-    # Override the "view on site" button to use local /documentation/ instead of docs.code.org path
+    # Override the "view on site" button to use local /docs/ instead of docs.code.org path
     def view_on_site(self, obj):
-        return '/documentation%s' % obj.get_absolute_url()
+        return '/docs%s' % obj.get_absolute_url()
 
 
 class MapAdmin(PageAdmin, VersionAdmin):

--- a/documentation/templates/documentation/map.html
+++ b/documentation/templates/documentation/map.html
@@ -21,7 +21,7 @@
         {% block categories %}
             <ul class="category_list">
             {% regroup maps by parent as map_menu %}
-                <h2><a href="/concepts/">Concepts</a></h2>
+                <h2><a href="/docs/concepts/">Concepts</a></h2>
             {% include "documentation/partials/map_menu.html" with map_menu=map_menu %}
             </ul>
         {% endblock %}

--- a/documentation/templates/documentation/pages.html
+++ b/documentation/templates/documentation/pages.html
@@ -28,7 +28,7 @@
 {% page_menu "pages/menus/tree.html" %}
         <h1>{{ curriculum.title }} {{ type }}</h1>
         {% for page in pages %}
-            <h2><a href="/documentation/{{ curriculum.slug }}/{{ page.slug }}">{{ page.title }}</a></h2>
+            <h2><a href="/docs/{{ curriculum.slug }}/{{ page.slug }}">{{ page.title }}</a></h2>
         {% endfor %}
     </div>
 {% endblock %}

--- a/documentation/templatetags/documentation_extras.py
+++ b/documentation/templatetags/documentation_extras.py
@@ -8,12 +8,8 @@ register = template.Library()
 
 @register.filter
 def get_absolute_url_for_host(map, host):
-    if host == 'curriculum.code.org' or host == 'www.codecurricula.com' or host == 'localhost:8000' or host == 'testserver':
-        return '/documentation/%s/' % map.slug
-    elif host == 'studio.code.org':
+    if host == 'testserver' or host == 'localhost:8000':
         return '/docs/%s/' % map.slug
-    elif host == 'docs.code.org':
-        return '/%s/' % map.slug
     else:
         logger.info("no known host %s" % host)
-        return '/%s/' % map.slug
+        return '/docs/%s/' % map.slug

--- a/documentation/tests/test_map_model.py
+++ b/documentation/tests/test_map_model.py
@@ -14,11 +14,5 @@ class MapModelTestCase(TestCase):
         self.assertIn(self.myChildMap, self.myMap.get_children())
 
     def test_get_absolute_url_for_host(self):
-        result = get_absolute_url_for_host(self.myMap, 'curriculum.code.org')
-        self.assertEqual(result, '/documentation/concepts/myConcept/')
-        result1 = get_absolute_url_for_host(self.myMap, 'www.codecurricula.com')
-        self.assertEqual(result1, '/documentation/concepts/myConcept/')
-        result2 = get_absolute_url_for_host(self.myMap, 'studio.code.org')
-        self.assertEqual(result2, '/docs/concepts/myConcept/')
-        result3 = get_absolute_url_for_host(self.myMap, 'docs.code.org')
-        self.assertEqual(result3, '/concepts/myConcept/')
+        result = get_absolute_url_for_host(self.myMap, 'testserver')
+        self.assertEqual(result, '/docs/concepts/myConcept/')


### PR DESCRIPTION
# Description

Continuing of #210 and #211.

This changes localhost, curriculum.code.org, and codecurricula.com to user /docs instead of /documentation. /documentation will still work tho if someone has an old link to it. This is one of two steps in getting all the urls for documentation closer to using the same paths.

Next will be figuring out how to make docs.code.org use the same pattern as well.


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-910)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Still haven't figured out the best way to test this all yet.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
