### PR TITLE
Add www.codecurricula.com back

### DIFF
--- a/curricula/urls.py
+++ b/curricula/urls.py
@@ -10,6 +10,7 @@ urlpatterns = patterns('curricula.views',
                        # Allow viewing concept documentations without the /documentation/ prefix
                        # so links work on both curriculumbuilder and docs.code.org
                        url(r'^(?P<slug>/concepts.*)/$', documentation_views.map_view, name="map_view"),
+                       url(r'^(?P<slug>/docs/concepts.*)/$', documentation_views.map_view, name="map_view"),
 
                        # Ajax endpoints
                        # Todo: fix Page history view

--- a/documentation/templatetags/documentation_extras.py
+++ b/documentation/templatetags/documentation_extras.py
@@ -8,7 +8,7 @@ register = template.Library()
 
 @register.filter
 def get_absolute_url_for_host(map, host):
-    if host == 'testserver' or host == 'localhost:8000':
+    if host == 'testserver' or host == 'localhost:8000' or host == 'www.codecurricula.com':
         return '/docs/%s/' % map.slug
     else:
         logger.info("no known host %s" % host)

--- a/documentation/tests/test_map_model.py
+++ b/documentation/tests/test_map_model.py
@@ -16,3 +16,7 @@ class MapModelTestCase(TestCase):
     def test_get_absolute_url_for_host(self):
         result = get_absolute_url_for_host(self.myMap, 'testserver')
         self.assertEqual(result, '/docs/concepts/myConcept/')
+        result2 = get_absolute_url_for_host(self.myMap, 'localhost:8000')
+        self.assertEqual(result2, '/docs/concepts/myConcept/')
+        result3 = get_absolute_url_for_host(self.myMap, 'www.codecurricula.com')
+        self.assertEqual(result3, '/docs/concepts/myConcept/')


### PR DESCRIPTION
# Description

Need the www.codecurricula.com as a host for menu to work.

Also make docs.code.org/docs and docs.code.org both go to the same place.