### PR TITLE
Revert "Use /docs instead of /documentation for links"

### DIFF
--- a/curriculumBuilder/urls.py
+++ b/curriculumBuilder/urls.py
@@ -107,7 +107,6 @@ urlpatterns += patterns('',
     url(r'^accounts/login/$', 'django.contrib.auth.views.login', {'template_name': 'admin/login.html'}),
     url(r'^admin_keywords_submit/$', generic_views.admin_keywords_submit, name='admin_keywords_submit'),
     url("^None/$", views.index),  # Dealing with JackFrost bug
-    url(r'^docs/', include('documentation.urls', namespace="documentation")),
     url(r'^documentation/', include('documentation.urls', namespace="documentation")),
     url(r'^standards/', include('standards.urls', namespace="standards")),
 )

--- a/documentation/admin.py
+++ b/documentation/admin.py
@@ -42,9 +42,9 @@ class IDEAdmin(PageAdmin, VersionAdmin):
         }),
     )
 
-    # Override the "view on site" button to use local /docs/ instead of docs.code.org path
+    # Override the "view on site" button to use local /documentation/ instead of docs.code.org path
     def view_on_site(self, obj):
-        return '/docs%s' % obj.get_absolute_url()
+        return '/documentation%s' % obj.get_absolute_url()
 
 
 class BlockForm(ModelForm):
@@ -99,9 +99,9 @@ class BlockAdmin(PageAdmin, VersionAdmin):
         models.CharField: {'widget': Textarea(attrs={'rows': 2})},
     }
 
-    # Override the "view on site" button to use local /docs/ instead of docs.code.org path
+    # Override the "view on site" button to use local /documentation/ instead of docs.code.org path
     def view_on_site(self, obj):
-        return '/docs%s' % obj.get_absolute_url()
+        return '/documentation%s' % obj.get_absolute_url()
 
 
 class MapAdmin(PageAdmin, VersionAdmin):

--- a/documentation/templates/documentation/map.html
+++ b/documentation/templates/documentation/map.html
@@ -21,7 +21,7 @@
         {% block categories %}
             <ul class="category_list">
             {% regroup maps by parent as map_menu %}
-                <h2><a href="/docs/concepts/">Concepts</a></h2>
+                <h2><a href="/concepts/">Concepts</a></h2>
             {% include "documentation/partials/map_menu.html" with map_menu=map_menu %}
             </ul>
         {% endblock %}

--- a/documentation/templates/documentation/pages.html
+++ b/documentation/templates/documentation/pages.html
@@ -28,7 +28,7 @@
 {% page_menu "pages/menus/tree.html" %}
         <h1>{{ curriculum.title }} {{ type }}</h1>
         {% for page in pages %}
-            <h2><a href="/docs/{{ curriculum.slug }}/{{ page.slug }}">{{ page.title }}</a></h2>
+            <h2><a href="/documentation/{{ curriculum.slug }}/{{ page.slug }}">{{ page.title }}</a></h2>
         {% endfor %}
     </div>
 {% endblock %}

--- a/documentation/templatetags/documentation_extras.py
+++ b/documentation/templatetags/documentation_extras.py
@@ -8,8 +8,12 @@ register = template.Library()
 
 @register.filter
 def get_absolute_url_for_host(map, host):
-    if host == 'testserver' or host == 'localhost:8000':
+    if host == 'curriculum.code.org' or host == 'www.codecurricula.com' or host == 'localhost:8000' or host == 'testserver':
+        return '/documentation/%s/' % map.slug
+    elif host == 'studio.code.org':
         return '/docs/%s/' % map.slug
+    elif host == 'docs.code.org':
+        return '/%s/' % map.slug
     else:
         logger.info("no known host %s" % host)
-        return '/docs/%s/' % map.slug
+        return '/%s/' % map.slug

--- a/documentation/tests/test_map_model.py
+++ b/documentation/tests/test_map_model.py
@@ -14,5 +14,11 @@ class MapModelTestCase(TestCase):
         self.assertIn(self.myChildMap, self.myMap.get_children())
 
     def test_get_absolute_url_for_host(self):
-        result = get_absolute_url_for_host(self.myMap, 'testserver')
-        self.assertEqual(result, '/docs/concepts/myConcept/')
+        result = get_absolute_url_for_host(self.myMap, 'curriculum.code.org')
+        self.assertEqual(result, '/documentation/concepts/myConcept/')
+        result1 = get_absolute_url_for_host(self.myMap, 'www.codecurricula.com')
+        self.assertEqual(result1, '/documentation/concepts/myConcept/')
+        result2 = get_absolute_url_for_host(self.myMap, 'studio.code.org')
+        self.assertEqual(result2, '/docs/concepts/myConcept/')
+        result3 = get_absolute_url_for_host(self.myMap, 'docs.code.org')
+        self.assertEqual(result3, '/concepts/myConcept/')


### PR DESCRIPTION
Reverts code-dot-org/curriculumbuilder#212