### PR TITLE
documentation links point to studio.code.org/docs instead of docs.code.org

### DIFF
--- a/documentation/models.py
+++ b/documentation/models.py
@@ -36,7 +36,7 @@ class IDE(Page, RichText, CloneableMixin):
         return '/%s/' % self.slug
 
     def get_published_url(self):
-        return '//docs.code.org/%s/' % self.slug
+        return '//studio.code.org/docs/%s/' % self.slug
 
     def jackfrost_urls(self):
         urls = ["/documentation%s" % self.get_absolute_url()]
@@ -159,7 +159,7 @@ class Block(Page, RichText, CloneableMixin):
         return '/%s/%s/' % (self.parent_ide.slug, self.slug)
 
     def get_published_url(self):
-        return '//docs.code.org/%s/%s/' % (self.parent_ide.slug, self.slug)
+        return '//studio.code.org/docs/%s/%s/' % (self.parent_ide.slug, self.slug)
 
     def jackfrost_urls(self):
         urls = ["/documentation%s" % self.get_absolute_url(), "/documentation%sembed/" % self.get_absolute_url()]
@@ -307,7 +307,7 @@ class Map(Page, RichText, CloneableMixin):
         return False
 
     def get_published_url(self):
-        return '//docs.code.org%s' % self.get_absolute_url()
+        return '//studio.code.org/docs%s' % self.get_absolute_url()
 
     def jackfrost_urls(self):
         urls = ["/documentation%s" % self.get_absolute_url()]


### PR DESCRIPTION
# Description

On curriculum builder we use the `get_published_url` for documentation in a couple of different places to determine the url we are sending people to for documentation. On of the them is the `/md` page for lesson plans which generates markdown for a student facing lesson plan which is used as the first level of most lessons. In addition, the blocks in lesson plans use this link. 

This changes those links to point to studio.code.org/docs instead of docs.code.org.

<img width="1436" alt="Screen Shot 2019-12-19 at 11 28 19 AM" src="https://user-images.githubusercontent.com/208083/71190547-c9693780-2252-11ea-8138-ffaa8ac6b696.png">
<img width="1430" alt="Screen Shot 2019-12-19 at 11 27 21 AM" src="https://user-images.githubusercontent.com/208083/71190548-c9693780-2252-11ea-8a5d-7dc80dd5f6d1.png">


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-910)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
