### PR TITLE
Add link for SFLP Markdown in admin menu of lesson

### DIFF
--- a/curricula/templates/curricula/partials/admin_menu.html
+++ b/curricula/templates/curricula/partials/admin_menu.html
@@ -65,7 +65,7 @@
                     <kbd draggable="true"
                      ondragstart="event.dataTransfer.setData('text/plain', '[v {{ vocab.word }}]')">[v {{ vocab.word }}]</kbd>
                 {% endfor %}
-                <h3><a href="{% url 'curriculum:lesson_markdown' curriculum.slug unit.slug lesson.number %}">Generate Student Facing Lesson Plan</a></h3>
+                <h3><a href="{% url 'curriculum:lesson_markdown' curriculum.slug unit.slug lesson.number %}" target="_blank">Generate Student Facing Lesson Plan</a></h3>
             {% endif %}
         </div>
         <ul class="drawer-nav">

--- a/curricula/templates/curricula/partials/admin_menu.html
+++ b/curricula/templates/curricula/partials/admin_menu.html
@@ -51,20 +51,21 @@
             {% endif %}
 
             {% if pagetype == "Lesson" %}
-            <h2>Resources</h2>
-            <ul>
-                {% for resource in page.resources.all %}
-                    <li>{{ resource }}</li>
+                <h2>Resources</h2>
+                <ul>
+                    {% for resource in page.resources.all %}
+                        <li>{{ resource }}</li>
+                        <kbd draggable="true"
+                            ondragstart="event.dataTransfer.setData('text/plain', '{{ resource.md_tag }}')">{{ resource.md_tag }}</kbd>
+                    {% endfor %}
+                </ul>
+                <h2>Vocab</h2>
+                {% for vocab in page.vocab.all %}
+                    <li>{{ vocab.word }}</li>
                     <kbd draggable="true"
-                         ondragstart="event.dataTransfer.setData('text/plain', '{{ resource.md_tag }}')">{{ resource.md_tag }}</kbd>
-                {% endfor %}
-            </ul>
-            <h2>Vocab</h2>
-            {% for vocab in page.vocab.all %}
-                <li>{{ vocab.word }}</li>
-                <kbd draggable="true"
                      ondragstart="event.dataTransfer.setData('text/plain', '[v {{ vocab.word }}]')">[v {{ vocab.word }}]</kbd>
-            {% endfor %}
+                {% endfor %}
+                <h3><a href="{% url 'curriculum:lesson_markdown' curriculum.slug unit.slug lesson.number %}">Generate Student Facing Lesson Plan</a></h3>
             {% endif %}
         </div>
         <ul class="drawer-nav">


### PR DESCRIPTION
# Description

We have this kind of secret way to generate the markdown for a Student Facing Lesson Plan (usually the first level of a lesson). It is just adding `/md` to the end of the lesson link. As we look to add more external editors to curriculum builder it would be nice to have an easy to access link for this so I added it to the admin menu on a lesson.


![markdown-link](https://user-images.githubusercontent.com/208083/71194118-5ca56b80-2259-11ea-801d-03155a2854c5.gif)
