### PR TITLE
Test for get_published_url for documentation models

### DIFF
--- a/documentation/factories.py
+++ b/documentation/factories.py
@@ -1,0 +1,27 @@
+from factory import Sequence, SubFactory
+from factory.django import DjangoModelFactory
+
+from documentation.models import Map, Block, IDE
+
+class MapFactory(DjangoModelFactory):
+    class Meta:
+        model = Map
+
+    title = Sequence(lambda n: "Concept %03d" % n)
+    slug = Sequence(lambda n: "/concepts/%03d" % n)
+
+class BlockFactory(DjangoModelFactory):
+    class Meta:
+        model = Block
+
+    title = Sequence(lambda n: "Block %03d" % n)
+    slug = Sequence(lambda n: "%03d" % n)
+    parent_ide = SubFactory('documentation.factories.IDEFactory')
+    parent = parent_ide
+
+class IDEFactory(DjangoModelFactory):
+    class Meta:
+        model = IDE
+
+    title = Sequence(lambda n: "IDE %03d" % n)
+    slug = Sequence(lambda n: "%03d" % n)

--- a/documentation/tests.py
+++ b/documentation/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/documentation/tests/test_documentation_models.py
+++ b/documentation/tests/test_documentation_models.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+
+from documentation.factories import MapFactory, IDEFactory, BlockFactory
+
+class DocumentationModelsTestCase(TestCase):
+
+    def setUp(self):
+        self.myMap = MapFactory(title='my concept parent', slug='concepts/myConcept')
+        self.myChildMap = MapFactory(title='my concept child', slug='concepts/myConcept/childConcept', parent=self.myMap)
+
+        self.myIDE = IDEFactory(title='Applab', slug='applab')
+        self.myBlock = BlockFactory(title='onEvent Block', slug='onEvent', parent_ide=self.myIDE, parent=self.myIDE)
+
+    def test_get_published_url(self):
+        result = self.myMap.get_published_url()
+        self.assertEqual(result, '//studio.code.org/docs/concepts/myConcept/')
+        result1 = self.myIDE.get_published_url()
+        self.assertEqual(result1, '//studio.code.org/docs/applab/')
+        result2 = self.myBlock.get_published_url()
+        self.assertEqual(result2, '//studio.code.org/docs/applab/onEvent/')


### PR DESCRIPTION
# Description

Creates basic factories for models in Documentation (IDE, Block, Map).

Creates a test for functions that were changed by #219. 
