### PR TITLE
Test admin documentation standards

### DIFF
--- a/documentation/factories.py
+++ b/documentation/factories.py
@@ -1,7 +1,7 @@
 from factory import Sequence, SubFactory
 from factory.django import DjangoModelFactory
 
-from documentation.models import Map, Block, IDE
+from documentation.models import Map, Block, IDE, Category
 
 class MapFactory(DjangoModelFactory):
     class Meta:
@@ -25,3 +25,10 @@ class IDEFactory(DjangoModelFactory):
 
     title = Sequence(lambda n: "IDE %03d" % n)
     slug = Sequence(lambda n: "%03d" % n)
+
+class CategoryFactory(DjangoModelFactory):
+    class Meta:
+        model = Category
+
+    name = Sequence(lambda n: "Category %03d" % n)
+    parent_ide = SubFactory('documentation.factories.IDEFactory')

--- a/documentation/tests/test_documentation_admin.py
+++ b/documentation/tests/test_documentation_admin.py
@@ -19,15 +19,15 @@ class DocumentationAdminTestCase(TestCase):
         siteperms.sites.add(site)
 
     def render_add(self, type):
-        response = self.client.get('/admin/documentation/'+type+'/add/')
+        response = self.client.get('/admin/documentation/%s/add/' % type)
         self.assertEqual(response.status_code, 403)
 
-        permission = Permission.objects.get(codename='add_'+type)
+        permission = Permission.objects.get(codename='add_%s' % type)
         self.user.user_permissions.add(permission)
 
-        response = self.client.get('/admin/documentation/'+type+'/add/')
+        response = self.client.get('/admin/documentation/%s/add/' % type)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Add '+type, response.content)
+        self.assertIn('Add %s' % type, response.content)
 
     def test_render_add_ide(self):
         self.render_add('ide')

--- a/documentation/tests/test_documentation_admin.py
+++ b/documentation/tests/test_documentation_admin.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+from django.contrib.auth.models import Permission
+from django.contrib.sites.models import Site
+
+from mezzanine.core.models import SitePermission
+
+from curricula.factories import UserFactory
+
+class DocumentationAdminTestCase(TestCase):
+    def setUp(self):
+        user = UserFactory()
+        user.is_staff = True
+        user.save()
+        self.user = user
+        self.assertTrue(self.client.login(username=user.username, password='password'))
+
+        site = Site.objects.first()
+        siteperms = SitePermission.objects.create(user=user)
+        siteperms.sites.add(site)
+
+    def render_add(self, type):
+        response = self.client.get('/admin/documentation/'+type+'/add/')
+        self.assertEqual(response.status_code, 403)
+
+        permission = Permission.objects.get(codename='add_'+type)
+        self.user.user_permissions.add(permission)
+
+        response = self.client.get('/admin/documentation/'+type+'/add/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Add '+type, response.content)
+
+    def test_render_add_ide(self):
+        self.render_add('ide')
+
+    def test_render_add_block(self):
+        self.render_add('block')
+
+    def test_render_add_map(self):
+        self.render_add('map')

--- a/documentation/tests/test_documentation_rendering.py
+++ b/documentation/tests/test_documentation_rendering.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from curricula.factories import CurriculumFactory, UnitFactory
 from lessons.factories import LessonFactory
 
-from documentation.factories import IDEFactory, BlockFactory, CategoryFactory
+from documentation.factories import IDEFactory, BlockFactory, CategoryFactory, MapFactory
 
 
 class DocumentationRenderingTestCase(TestCase):
@@ -17,6 +17,9 @@ class DocumentationRenderingTestCase(TestCase):
 
         self.test_lesson = LessonFactory(title="My Lesson", parent=self.test_unit)
         self.test_lesson.blocks.add(self.myBlock)
+
+        self.myConcept = MapFactory(slug="concepts", title="Concepts")
+        self.myMap = MapFactory(slug="concepts/myMap", title="My Map", parent=self.myConcept)
 
     def test_render_course_blocks_page(self):
         response = self.client.get('/test-curriculum/code/')
@@ -40,3 +43,12 @@ class DocumentationRenderingTestCase(TestCase):
         self.assertEqual(response2.status_code, 200)
         self.assertIn('myCategory', response2.content)
         self.assertIn('myBlock', response2.content)
+
+    def test_render_maps(self):
+        response = self.client.get('/documentation/concepts/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Concepts', response.content)
+        response2 = self.client.get('/documentation/concepts/myMap/')
+        self.assertEqual(response2.status_code, 200)
+        self.assertIn('My Map', response2.content)
+        self.assertIn('Concepts', response2.content)

--- a/documentation/tests/test_documentation_rendering.py
+++ b/documentation/tests/test_documentation_rendering.py
@@ -3,13 +3,14 @@ from django.test import TestCase
 from curricula.factories import CurriculumFactory, UnitFactory
 from lessons.factories import LessonFactory
 
-from documentation.factories import IDEFactory, BlockFactory
+from documentation.factories import IDEFactory, BlockFactory, CategoryFactory
 
 
 class DocumentationRenderingTestCase(TestCase):
     def setUp(self):
-        self.myIDE = IDEFactory(slug="myIDE")
-        self.myBlock = BlockFactory(slug="myBlock", title="My Block", parent_ide=self.myIDE, parent=self.myIDE)
+        self.myIDE = IDEFactory(slug="mylab")
+        self.myCategory = CategoryFactory(name="myCategory", parent_ide=self.myIDE)
+        self.myBlock = BlockFactory(slug="myBlock", title="myBlock", parent_ide=self.myIDE, parent=self.myIDE, parent_cat=self.myCategory)
 
         self.test_curriculum = CurriculumFactory(slug="test-curriculum")
         self.test_unit = UnitFactory(parent=self.test_curriculum, slug="test-unit")
@@ -21,10 +22,21 @@ class DocumentationRenderingTestCase(TestCase):
         response = self.client.get('/test-curriculum/code/')
         self.assertEqual(response.status_code, 200)
         self.assertIn('My Lesson', response.content)
-        self.assertIn('My Block', response.content)
+        self.assertIn('myBlock', response.content)
 
     def test_render_lesson_includes_blocks(self):
         response = self.client.get('/test-curriculum/test-unit/1/')
         self.assertEqual(response.status_code, 200)
         self.assertIn('Introduced Code', response.content)
-        self.assertIn('My Block', response.content)
+        self.assertIn('myBlock', response.content)
+
+    def test_render_ide_blocks(self):
+        response = self.client.get('/documentation/mylab/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Try it out', response.content)
+        self.assertIn('myCategory', response.content)
+        self.assertIn('myBlock', response.content)
+        response2 = self.client.get('/documentation/mylab/myBlock/')
+        self.assertEqual(response2.status_code, 200)
+        self.assertIn('myCategory', response2.content)
+        self.assertIn('myBlock', response2.content)

--- a/standards/tests/test_standards_admin.py
+++ b/standards/tests/test_standards_admin.py
@@ -20,15 +20,15 @@ class StandardsAdminTestCase(TestCase):
         siteperms.sites.add(site)
 
     def render_add(self, type):
-        response = self.client.get('/admin/standards/' + type + '/add/')
+        response = self.client.get('/admin/standards/%s/add/' % type)
         self.assertEqual(response.status_code, 403)
 
-        permission = Permission.objects.get(content_type__app_label='standards', codename='add_' + type)
+        permission = Permission.objects.get(content_type__app_label='standards', codename='add_%s' % type)
         self.user.user_permissions.add(permission)
 
-        response = self.client.get('/admin/standards/' + type + '/add/')
+        response = self.client.get('/admin/standards/%s/add/' % type)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Add ' + type, response.content)
+        self.assertIn('Add %s' % type, response.content)
 
     def test_render_add_category(self):
         self.render_add('category')

--- a/standards/tests/test_standards_admin.py
+++ b/standards/tests/test_standards_admin.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from django.contrib.auth.models import Permission
+from django.contrib.sites.models import Site
+
+from mezzanine.core.models import SitePermission
+
+from curricula.factories import UserFactory
+
+
+class StandardsAdminTestCase(TestCase):
+    def setUp(self):
+        user = UserFactory()
+        user.is_staff = True
+        user.save()
+        self.user = user
+        self.assertTrue(self.client.login(username=user.username, password='password'))
+
+        site = Site.objects.first()
+        siteperms = SitePermission.objects.create(user=user)
+        siteperms.sites.add(site)
+
+    def render_add(self, type):
+        response = self.client.get('/admin/standards/' + type + '/add/')
+        self.assertEqual(response.status_code, 403)
+
+        permission = Permission.objects.get(content_type__app_label='standards', codename='add_' + type)
+        self.user.user_permissions.add(permission)
+
+        response = self.client.get('/admin/standards/' + type + '/add/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Add ' + type, response.content)
+
+    def test_render_add_category(self):
+        self.render_add('category')
+
+    def test_render_add_standard(self):
+        self.render_add('standard')
+
+    def test_render_add_framework(self):
+        self.render_add('framework')


### PR DESCRIPTION
# Description

Creates basic tests for admin abilities for documentation and standards. It only tests the add permissions and add pages (not change or delete). This is how we were testing for curricula and lesson.


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1053)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
