### PR TITLE
Create docs landing

### DIFF
--- a/documentation/templates/documentation/index.html
+++ b/documentation/templates/documentation/index.html
@@ -1,0 +1,51 @@
+{% extends "basecurriculum.html" %}
+
+{% load staticfiles %}
+{% load mezzanine_tags %}
+{% load keyword_tags %}
+
+{% block meta_title %}Documentation{% endblock %}
+
+{% block meta_keywords %}{% metablock %}
+    {% keywords_for page as keywords %}
+    {% for keyword in keywords %}
+        {% if not forloop.first %}, {% endif %}
+        {{ keyword }}
+    {% endfor %}
+{% endmetablock %}{% endblock %}
+
+{% block meta_description %}{% metablock %}
+    {{ page.description }}
+{% endmetablock %}{% endblock %}
+
+{% block title %}
+    {% editable page.title %}{{ page.title }}{% endeditable %}
+{% endblock %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="{% static "css/lesson.css" %}">
+{% endblock %}
+
+{% block header_title %}
+    <h1>Documentation</h1>
+{% endblock %}
+
+{% block main %}
+    <h2>IDEs</h2>
+    {% for ide in ides %}
+    <ul class="together">
+        <li><h3><a href="{{ide.slug}}">{{ide.title}}</a></h3></li>
+    </ul>
+    {% endfor %}
+
+    <h2><a href="/docs/concepts">Concepts</a></h2>
+    <div id="categories">
+        {% block categories %}
+            <ul class="category_list">
+            {% regroup maps by parent as map_menu %}
+            {% include "documentation/partials/map_menu.html" with map_menu=map_menu %}
+            </ul>
+        {% endblock %}
+    </div>
+
+{% endblock %}

--- a/documentation/tests/test_documentation_rendering.py
+++ b/documentation/tests/test_documentation_rendering.py
@@ -8,7 +8,7 @@ from documentation.factories import IDEFactory, BlockFactory, CategoryFactory, M
 
 class DocumentationRenderingTestCase(TestCase):
     def setUp(self):
-        self.myIDE = IDEFactory(slug="mylab")
+        self.myIDE = IDEFactory(title="My IDE", slug="mylab")
         self.myCategory = CategoryFactory(name="My Category", parent_ide=self.myIDE)
         self.myBlock = BlockFactory(slug="myBlock", title="My Block", parent_ide=self.myIDE, parent=self.myIDE, parent_cat=self.myCategory)
 
@@ -32,6 +32,20 @@ class DocumentationRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('Introduced Code', response.content)
         self.assertIn('My Block', response.content)
+
+    def test_render_documentation_landing(self):
+        response = self.client.get('/documentation/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('IDEs', response.content)
+        self.assertIn('My IDE', response.content)
+        self.assertIn('Concepts', response.content)
+        self.assertIn('My Map', response.content)
+        response2 = self.client.get('/docs/')
+        self.assertEqual(response2.status_code, 200)
+        self.assertIn('IDEs', response2.content)
+        self.assertIn('My IDE', response2.content)
+        self.assertIn('Concepts', response2.content)
+        self.assertIn('My Map', response2.content)
 
     def test_render_ide_blocks(self):
         response = self.client.get('/documentation/mylab/')

--- a/documentation/urls.py
+++ b/documentation/urls.py
@@ -5,6 +5,7 @@ from documentation import views
 
 urlpatterns = [
     multiurl(
+        url(r'^$', views.index, name='index'),
         url(r'^(?P<slug>.*)/$', views.map_view, name="map_view"),
 
         # Assumes that all IDEs with docs end in lab to avoid routing conflicts with curriculum routes

--- a/documentation/views.py
+++ b/documentation/views.py
@@ -6,8 +6,12 @@ from multiurl import ContinueResolving
 from mezzanine.pages.models import Page
 
 from models import IDE, Block, Map
-from curricula.models import Curriculum
 
+
+def index(request):
+    ides = IDE.objects.all()
+    maps = Map.objects.all()
+    return render(request, 'documentation/index.html', {'ides': ides, 'maps': maps})
 
 def ide_view(request, slug):
     try:


### PR DESCRIPTION
# Description

Currently if you go to curriculum.code.org/documentation/ (also curriculum.code.org/docs) you get an error. This creates a page for the url so that if you end up there you can get to any of the IDE documentation or the concept maps. It is not a very pretty page but its better than an error.

![Screen Shot 2020-01-08 at 1 21 28 PM](https://user-images.githubusercontent.com/208083/72004939-77e11680-321a-11ea-9890-426a53ea8647.png)


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1138)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Created a render test for the page.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
