### PR TITLE
Add help text for google doc checkbox

### DIFF
--- a/lessons/models.py
+++ b/lessons/models.py
@@ -893,6 +893,7 @@ class Annotation(models.Model):
 Lesson._meta.get_field('login_required').verbose_name = 'Hidden'
 Lesson._meta.get_field('login_required').help_text = "Hide from listings and prevent be publishing."
 Lesson._meta.get_field('status').help_text = "With draft chosen this lesson will not be updated during publish."
+Resource._meta.get_field('gd').help_text = "Only check this box for a google doc (Not google presentation, spreadsheet, etc)"
 
 reversion.register(Activity, follow=('lesson', ))
 reversion.register(Objective, follow=('lesson', ))


### PR DESCRIPTION
Users keep checking the google doc box on resources if its any google resource (spreadsheet, presentation, etc). It is ONLY for google docs. This adds help text to hopefully help people from checking the box at the wrong times.

![Screen Shot 2020-01-10 at 3 51 31 PM](https://user-images.githubusercontent.com/208083/72185634-4a829d00-33c1-11ea-99a2-f18c93617b66.png)
