### PR TITLE
Make documentation also publish to /docs in addition to /documentation

### DIFF
--- a/documentation/models.py
+++ b/documentation/models.py
@@ -39,7 +39,7 @@ class IDE(Page, RichText, CloneableMixin):
         return '//studio.code.org/docs/%s/' % self.slug
 
     def jackfrost_urls(self):
-        urls = ["/documentation%s" % self.get_absolute_url()]
+        urls = ["/documentation%s" % self.get_absolute_url(), "/docs%s" % self.get_absolute_url()]
         return urls
 
     def jackfrost_can_build(self):
@@ -162,7 +162,7 @@ class Block(Page, RichText, CloneableMixin):
         return '//studio.code.org/docs/%s/%s/' % (self.parent_ide.slug, self.slug)
 
     def jackfrost_urls(self):
-        urls = ["/documentation%s" % self.get_absolute_url(), "/documentation%sembed/" % self.get_absolute_url()]
+        urls = ["/documentation%s" % self.get_absolute_url(), "/documentation%sembed/" % self.get_absolute_url(), "/docs%s" % self.get_absolute_url(), "/docs%sembed/" % self.get_absolute_url()]
         return urls
 
     def jackfrost_can_build(self):
@@ -317,7 +317,7 @@ class Map(Page, RichText, CloneableMixin):
         return '//studio.code.org/docs%s' % self.get_absolute_url()
 
     def jackfrost_urls(self):
-        urls = ["/documentation%s" % self.get_absolute_url()]
+        urls = ["/documentation%s" % self.get_absolute_url(), "/docs%s" % self.get_absolute_url()]
         return urls
 
     def jackfrost_can_build(self):

--- a/documentation/tests/test_documentation_models.py
+++ b/documentation/tests/test_documentation_models.py
@@ -18,3 +18,11 @@ class DocumentationModelsTestCase(TestCase):
         self.assertEqual(result1, '//studio.code.org/docs/applab/')
         result2 = self.myBlock.get_published_url()
         self.assertEqual(result2, '//studio.code.org/docs/applab/onEvent/')
+
+    def test_jackfrost_url(self):
+        result = self.myMap.jackfrost_urls()
+        self.assertEqual(result, ['/documentation/concepts/myConcept/','/docs/concepts/myConcept/'])
+        result1 = self.myIDE.jackfrost_urls()
+        self.assertEqual(result1, ['/documentation/applab/', '/docs/applab/'])
+        result2 = self.myBlock.jackfrost_urls()
+        self.assertEqual(result2, ['/documentation/applab/onEvent/', '/documentation/applab/onEvent/embed/', '/docs/applab/onEvent/', '/docs/applab/onEvent/embed/'])


### PR DESCRIPTION
# Description

In an effort to consolidate the number of ways you can access documentation we are trying to move toward everything using /docs. curriculum.code.org currently uses /documentation because thats where the pages get published to on S3. Jackfrost is the thing we use to publish and the url it publishes to is determined by `jackfrost_url`.

This makes it so we will both publish to /documentation and /docs on S3. Once we publish everything and confirm its working at /docs then we can stop publishing to /documentation and just redirect /documentation to /docs.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1137)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

I created a unit test for the `jackfrost_urls` method. I don't know that I can test that the action of publishing works locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
