### PR TITLE
Standards description and category in csv

### DIFF
--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -164,3 +164,11 @@ class CurriculaRenderingTestCase(TestCase):
         self.test_lesson.save()
         response = self.client.get('/test-curriculum/test-unit/1/')
         self.assertEqual(response.status_code, 200)
+
+    def test_metadata_for_course(self):
+        response = self.client.get('/metadata/course/test-curriculum.json')
+        self.assertEqual(response.status_code, 200)
+
+    def test_metadata_for_unit(self):
+        response = self.client.get('/metadata/test-stage-name.json')
+        self.assertEqual(response.status_code, 200)

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -170,5 +170,5 @@ class CurriculaRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_metadata_for_unit(self):
-        response = self.client.get('/metadata/test-stage-name.json')
+        response = self.client.get('/metadata/test-unit.json')
         self.assertEqual(response.status_code, 200)

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -20,7 +20,7 @@ class CurriculaRenderingTestCase(TestCase):
         self.pl_curriculum = CurriculumFactory(
             slug="pl-curriculum",
             unit_template_override='curricula/pl_unit.html')
-        self.test_unit = UnitFactory(parent=self.test_curriculum, slug="test-unit")
+        self.test_unit = UnitFactory(parent=self.test_curriculum, slug="test-unit", stage_name="test-stage-name")
         self.hoc_unit = UnitFactory(
             parent=self.test_curriculum,
             slug="hoc-unit",
@@ -170,5 +170,5 @@ class CurriculaRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_metadata_for_unit(self):
-        response = self.client.get('/metadata/test-unit.json')
+        response = self.client.get('/metadata/test-stage-name.json')
         self.assertEqual(response.status_code, 200)

--- a/standards/tests/test_standards_rendering.py
+++ b/standards/tests/test_standards_rendering.py
@@ -32,14 +32,6 @@ class StandardsRenderingTestCase(TestCase):
         self.assertIn('Standards Alignment', response.content)
         self.assertIn('Test Standard', response.content)
 
-    def test_metadata_for_course(self):
-        response = self.client.get('/metadata/course/test-curriculum.json')
-        self.assertEqual(response.status_code, 200)
-
-    def test_metadata_for_unit(self):
-        response = self.client.get('/metadata/test-stage-name.json')
-        self.assertEqual(response.status_code, 200)
-
     def test_standards_metadata_for_unit(self):
         response = self.client.get('/metadata/test-stage-name/standards.json')
         self.assertEqual(response.status_code, 200)

--- a/standards/views.py
+++ b/standards/views.py
@@ -47,19 +47,43 @@ def by_curriculum_csv(request, slug):
     response['Content-Disposition'] = 'attachment; filename="%s_standards.csv"' % curriculum.slug
 
     writer = csv.writer(response, encoding='utf-8')
-    writer.writerow(['curriculum', 'unit', 'lesson #', 'lesson name',
-                     'standard framework', 'standard', 'category', 'description', 'cross curricular opportunity'])
+    writer.writerow([
+        'curriculum',
+        'unit',
+        'lesson #',
+        'lesson name',
+        'standard framework',
+        'standard',
+        'category',
+        'description',
+        'cross curricular opportunity'
+    ])
     for unit in curriculum.units:
         for lesson in unit.lessons:
             for standard in lesson.standards.all():
-                writer.writerow([curriculum.slug, unit.slug, 'lesson %d' % lesson.number, lesson.title,
-                                 standard.framework.slug,
-                                 standard.shortcode,
-                                 standard.category.name, standard.name, False])
+                writer.writerow([
+                    curriculum.slug,
+                    unit.slug,
+                    'lesson %d' % lesson.number,
+                    lesson.title,
+                    standard.framework.slug,
+                    standard.shortcode,
+                    standard.category.name,
+                    standard.name,
+                    False
+                ])
             for standard in lesson.opportunity_standards.all():
-                writer.writerow([curriculum.slug, unit.slug, 'lesson %d' % lesson.number, lesson.title,
-                                 standard.framework.slug,
-                                  standard.shortcode, standard.category.name, standard.name, True])
+                writer.writerow([
+                    curriculum.slug,
+                    unit.slug,
+                    'lesson %d' % lesson.number,
+                    lesson.title,
+                    standard.framework.slug,
+                    standard.shortcode,
+                    standard.category.name,
+                    standard.name,
+                    True
+                ])
     return response
 
 
@@ -87,15 +111,42 @@ def by_unit_csv(request, slug, unit_slug):
     response['Content-Disposition'] = 'attachment; filename="%s_%s_standards.csv"' % (curriculum.slug, unit.slug)
 
     writer = csv.writer(response, encoding='utf-8')
-    writer.writerow(['curriculum', 'unit', 'lesson #', 'lesson name',
-                     'standard framework', 'standard', 'category', 'description', 'cross curricular opportunity'])
+    writer.writerow([
+        'curriculum',
+        'unit',
+        'lesson #',
+        'lesson name',
+        'standard framework',
+        'standard',
+        'category',
+        'description',
+        'cross curricular opportunity'
+    ])
     for lesson in unit.lessons:
         for standard in lesson.standards.all():
-            writer.writerow([curriculum.slug, unit.slug, 'lesson %d' % lesson.number, lesson.title,
-                             standard.framework.slug, standard.shortcode, standard.category.name, standard.name, 'false'])
+            writer.writerow([
+                curriculum.slug,
+                unit.slug,
+                'lesson %d' % lesson.number,
+                lesson.title,
+                standard.framework.slug,
+                standard.shortcode,
+                standard.category.name,
+                standard.name,
+                'false'
+            ])
         for standard in lesson.opportunity_standards.all():
-            writer.writerow([curriculum.slug, unit.slug, 'lesson %d' % lesson.number, lesson.title,
-                             standard.framework.slug, standard.shortcode, standard.category.name, standard.name, 'true'])
+            writer.writerow([
+                curriculum.slug,
+                unit.slug,
+                'lesson %d' % lesson.number,
+                lesson.title,
+                standard.framework.slug,
+                standard.shortcode,
+                standard.category.name,
+                standard.name,
+                'true'
+            ])
     return response
 
 

--- a/standards/views.py
+++ b/standards/views.py
@@ -48,15 +48,18 @@ def by_curriculum_csv(request, slug):
 
     writer = csv.writer(response, encoding='utf-8')
     writer.writerow(['curriculum', 'unit', 'lesson #', 'lesson name',
-                     'standard framework', 'standard', 'cross curricular opportunity'])
+                     'standard framework', 'standard', 'category', 'description', 'cross curricular opportunity'])
     for unit in curriculum.units:
         for lesson in unit.lessons:
             for standard in lesson.standards.all():
                 writer.writerow([curriculum.slug, unit.slug, 'lesson %d' % lesson.number, lesson.title,
-                                 standard.framework.slug, standard.shortcode, False])
+                                 standard.framework.slug,
+                                 standard.shortcode,
+                                 standard.category.name, standard.name, False])
             for standard in lesson.opportunity_standards.all():
                 writer.writerow([curriculum.slug, unit.slug, 'lesson %d' % lesson.number, lesson.title,
-                                 standard.framework.slug, standard.shortcode, True])
+                                 standard.framework.slug,
+                                  standard.shortcode, standard.category.name, standard.name, True])
     return response
 
 
@@ -85,14 +88,14 @@ def by_unit_csv(request, slug, unit_slug):
 
     writer = csv.writer(response, encoding='utf-8')
     writer.writerow(['curriculum', 'unit', 'lesson #', 'lesson name',
-                     'standard framework', 'standard', 'cross curricular opportunity'])
+                     'standard framework', 'standard', 'category', 'description', 'cross curricular opportunity'])
     for lesson in unit.lessons:
         for standard in lesson.standards.all():
             writer.writerow([curriculum.slug, unit.slug, 'lesson %d' % lesson.number, lesson.title,
-                             standard.framework.slug, standard.shortcode, 'false'])
+                             standard.framework.slug, standard.shortcode, standard.category.name, standard.name, 'false'])
         for standard in lesson.opportunity_standards.all():
             writer.writerow([curriculum.slug, unit.slug, 'lesson %d' % lesson.number, lesson.title,
-                             standard.framework.slug, standard.shortcode, 'true'])
+                             standard.framework.slug, standard.shortcode, standard.category.name, standard.name, 'true'])
     return response
 
 


### PR DESCRIPTION
[LP-1151](https://codedotorg.atlassian.net/browse/LP-1151) 

Teachers requested that the CSV download of standards include the description of the standard in the table. Turns out this is useful for the engineering work we're doing to show standards associations on the teacher dashboard too 🙂

BEFORE: 
CSV download includes columns for: curriculum, unit, lesson #, lesson name, standard framework, standard and cross curricular opportunity 
<img width="763" alt="Screen Shot 2020-01-15 at 12 38 36 PM" src="https://user-images.githubusercontent.com/12300669/72469598-9902b380-3794-11ea-9c76-2b09508e76b8.png">

AFTER: 
CSV download includes columns for: curriculum, unit, lesson #, lesson name, standard framework, standard, category, description and cross curricular opportunity 
<img width="1278" alt="Screen Shot 2020-01-15 at 12 38 09 PM" src="https://user-images.githubusercontent.com/12300669/72469601-9acc7700-3794-11ea-8402-6420dd721f57.png">

These updates were made in two places: the csv by unit and csv by curriculum methods. 

This PR also contains a small clean up from https://github.com/code-dot-org/curriculumbuilder/pull/230#discussion_r365233556 where I move tests to a better location. 