### PR TITLE
Limit standards metadata to needed fields

### DIFF
--- a/curricula/serializers.py
+++ b/curricula/serializers.py
@@ -108,7 +108,7 @@ class UnitLessonsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Unit
-        fields = ('title', 'slug', 'lessons')
+        fields = ('stage_name', 'lessons')
 
     def get_lessons(self, obj):
         lessons = obj.lessons

--- a/curricula/serializers.py
+++ b/curricula/serializers.py
@@ -35,15 +35,11 @@ class BlockSerializer(serializers.ModelSerializer):
         return obj.get_published_url()
 
 class StandardSerializer(serializers.ModelSerializer):
-    category = serializers.SerializerMethodField()
     framework = serializers.SerializerMethodField()
 
     class Meta:
         model = Standard
-        fields = ('name', 'shortcode', 'description', 'category', 'framework', 'slug')
-
-    def get_category(self, obj):
-        return obj.category.name
+        fields = ('shortcode', 'framework')
 
     def get_framework(self, obj):
         return obj.framework.slug


### PR DESCRIPTION
Follow up to #230 

Since the standards don't change once they're released, we're relying on CSV upload of the standards and don't need the description, name or category here. We're only using the CB metadata to establish the association between a standard and a stage/lesson. Framework  (Code Studio "organization" on the Standards model) and shortcode (Code Studio "organization_id" on the Standards model) will be sufficient to identify the standard in Code Studio.  

BEFORE:
<img width="958" alt="Screen Shot 2020-01-10 at 9 16 39 PM" src="https://user-images.githubusercontent.com/12300669/72475525-ee908d80-379f-11ea-9228-904ef33a5019.png">

AFTER: 
<img width="797" alt="Screen Shot 2020-01-15 at 2 04 25 PM" src="https://user-images.githubusercontent.com/12300669/72475546-fb14e600-379f-11ea-87de-dda5d4c2da8f.png">
