### PR TITLE
Limit pdf generation to a handful of languages

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -10,6 +10,7 @@ from django.db.models import Count, Q
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils.text import slugify
+from django.utils.translation import get_language
 
 from mezzanine.pages.models import Page, RichText, Orderable, PageMoveException
 from mezzanine.core.fields import RichTextField
@@ -104,7 +105,12 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return reverse('curriculum:curriculum_view', args=[self.slug])
 
     def get_pdf_url(self):
-        return reverse('curriculum:curriculum_pdf', args=[self.slug])
+        url = reverse('curriculum:curriculum_pdf', args=[self.slug])
+        language = get_language()
+        if (language != 'en-us' and language not in settings.LANGUAGE_GENERATE_PDF):
+            m = re.match(r'(/[^/]*)(/.*$)', url)
+            url = m.groups()[1]
+        return url
 
     def get_json_url(self):
         return reverse('curriculum:curriculum_element', args=[self.slug])
@@ -359,7 +365,13 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return reverse('curriculum:unit_compiled', args=[self.curriculum.slug, self.slug])
 
     def get_pdf_url(self):
-        return reverse('curriculum:unit_pdf', args=[self.curriculum.slug, self.slug])
+        url = reverse('curriculum:unit_pdf', args=[self.curriculum.slug, self.slug])
+        language = get_language()
+        if (language != 'en-us' and language not in settings.LANGUAGE_GENERATE_PDF):
+            # If we don't support PDFs for this language, link to the English PDF
+            m = re.match(r'(/[^/]*)(/.*$)', url)
+            url = m.groups()[1]
+        return url
 
     def get_json_url(self):
         return reverse('curriculum:stage_element', args=[self.stage_name])

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -10,6 +10,7 @@ from django.db.models import Count, Q
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils.text import slugify
+from django.utils import translation
 from django.utils.translation import get_language
 
 from mezzanine.pages.models import Page, RichText, Orderable, PageMoveException
@@ -105,12 +106,11 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return reverse('curriculum:curriculum_view', args=[self.slug])
 
     def get_pdf_url(self):
-        url = reverse('curriculum:curriculum_pdf', args=[self.slug])
         language = get_language()
         if (language != 'en-us' and language not in settings.LANGUAGE_GENERATE_PDF):
-            m = re.match(r'(/[^/]*)(/.*$)', url)
-            url = m.groups()[1]
-        return url
+            language = settings.LANGUAGE_CODE
+        with translation.override(language):
+            return reverse('curriculum:curriculum_pdf', args=[self.slug])
 
     def get_json_url(self):
         return reverse('curriculum:curriculum_element', args=[self.slug])
@@ -365,13 +365,11 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return reverse('curriculum:unit_compiled', args=[self.curriculum.slug, self.slug])
 
     def get_pdf_url(self):
-        url = reverse('curriculum:unit_pdf', args=[self.curriculum.slug, self.slug])
         language = get_language()
         if (language != 'en-us' and language not in settings.LANGUAGE_GENERATE_PDF):
-            # If we don't support PDFs for this language, link to the English PDF
-            m = re.match(r'(/[^/]*)(/.*$)', url)
-            url = m.groups()[1]
-        return url
+            language = settings.LANGUAGE_CODE
+        with translation.override(language):
+            return reverse('curriculum:unit_pdf', args=[self.curriculum.slug, self.slug])
 
     def get_json_url(self):
         return reverse('curriculum:stage_element', args=[self.stage_name])

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -172,3 +172,10 @@ class CurriculaRenderingTestCase(TestCase):
     def test_metadata_for_unit(self):
         response = self.client.get('/metadata/test-stage-name.json')
         self.assertEqual(response.status_code, 200)
+
+    def test_get_pdf_url(self):
+        en_url = self.csf_unit.get_pdf_url()
+        with translation.override('es-mx'):
+            es_url = self.csf_unit.get_pdf_url()
+        with translation.override('hi-in'):
+            hi_url = self.csf_unit.get_pdf_url()

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.contrib.auth.models import Permission
+from django.utils import translation
 
 from curricula.factories import UserFactory, CurriculumFactory, UnitFactory
 from lessons.factories import LessonFactory, ResourceFactory

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -180,3 +180,6 @@ class CurriculaRenderingTestCase(TestCase):
             es_url = self.csf_unit.get_pdf_url()
         with translation.override('hi-in'):
             hi_url = self.csf_unit.get_pdf_url()
+        self.assertEqual('/csf-curriculum/csf-unit.pdf', en_url)
+        self.assertEqual('/es-mx/csf-curriculum/csf-unit.pdf', es_url)
+        self.assertEqual('/csf-curriculum/csf-unit.pdf', hi_url)

--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -133,6 +133,14 @@ LANGUAGES = (
     ('th-th', _('Thai')),
     ('sk-sk', _('Slovak')),
     (LANGUAGE_CODE_DO_TRANSLATION, _('Translate')),
+    ('hi-in', _('Hindi'))
+)
+
+LANGUAGE_GENERATE_PDF = (
+    'es-mx',
+    'it-it',
+    'th-th',
+    'sk-sk',
 )
 
 LOCALE_PATHS = (

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -19,8 +19,7 @@ class Command(BaseCommand):
     ]
 
     language_codes = [
-        (language_code, language_code in settings.LANGUAGE_GENERATE_PDF)
-        for language_code, _ in settings.LANGUAGES
+        language_code for language_code, _ in settings.LANGUAGES
         if language_code != settings.LANGUAGE_CODE
     ]
 
@@ -30,11 +29,7 @@ class Command(BaseCommand):
         that define them
         """
         log("Models to publish: %s" % ', '.join(model.__name__ for model in self.models))
-        log("Languages to publish: %s" % ', '.
-                join(language_code for (language_code, _) in self.language_codes))
-        log("Languages to publish PDFs: %s" % ', '.
-                join(language_code for (language_code, publish_pdf)
-                    in self.language_codes if publish_pdf))
+        log("Languages to publish: %s" % ', '.join(self.language_codes))
 
         total_elapsed_time = 0
         for model_index, model in enumerate(self.models):
@@ -49,11 +44,11 @@ class Command(BaseCommand):
                 if not obj.should_be_translated:
                     continue
 
-                for language_code, publish_pdf in self.language_codes:
+                for language_code in self.language_codes:
                     translation.activate(language_code)
                     if hasattr(obj, 'publish'):
                         list(obj.publish(silent=True))
-                    if publish_pdf and hasattr(obj, 'publish_pdfs'):
+                    if language_code in settings.LANGUAGE_GENERATE_PDF and hasattr(obj, 'publish_pdfs'):
                         list(obj.publish_pdfs(silent=True))
                 success_count += 1
 


### PR DESCRIPTION
# Description

We've wanted to add more language options to CB for a while. We haven't as the sync takes several hours every day. We believe that PDF generation is a major bottleneck, so this PR adds a way to limit the languages that generate translated PDFs. Languages that don't have translated PDFs will link to the English version.

This PR does add Hindi as a language option as I was testing these features out with Hindi. If we would prefer to keep adding a language separate, I can remove it.



# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
