### PR TITLE
Change stage_name to unit_name to avoid further confusion

### DIFF
--- a/curricula/admin.py
+++ b/curricula/admin.py
@@ -102,13 +102,13 @@ class UnitAdmin(PageAdmin, VersionAdmin, FilterableAdmin):
         # TODO: Only super admins should have in_sitemap as an option. It removes the curriculum from the Pages List
         if self.can_access_all(request):
             general_fields = ['title', 'status', ('publish_date', 'expiry_date'), 'content', 'ancestor',
-                           'disable_numbering', 'number', 'stage_name', 'questions', 'assessment_commentary',
+                           'disable_numbering', 'number', 'unit_name', 'questions', 'assessment_commentary',
                            'show_calendar', 'week_length', 'forum_url', 'forum_vars', 'lesson_template_override',
                            'i18n_ready', 'in_menus', 'login_required']
             meta_data_fields = ['_meta_title', 'slug', ('description', 'gen_description'), 'keywords', 'in_sitemap']
         else:
             general_fields = ['title', 'content',
-                           'disable_numbering', 'number', 'stage_name', 'questions', 'assessment_commentary',
+                           'disable_numbering', 'number', 'unit_name', 'questions', 'assessment_commentary',
                            'show_calendar', 'week_length', 'lesson_template_override']
             meta_data_fields = ['_meta_title', 'slug', ('description', 'gen_description'), 'keywords']
 

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -298,7 +298,7 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
     ancestor = models.ForeignKey('self', blank=True, null=True, on_delete=models.SET_NULL)
     disable_numbering = models.BooleanField(default=False, help_text="Override to disable unit numbering")
     number = models.IntegerField('Number', blank=True, null=True)
-    stage_name = models.CharField('Script', max_length=255, blank=True, null=True,
+    unit_name = models.CharField('Script', max_length=255, blank=True, db_column='stage_name', null=True,
                                   help_text='Name of Code Studio script')
     questions = RichTextField('Support Details', help_text='Open questions or comments to add to all lessons in unit',
                               blank=True, null=True)
@@ -372,7 +372,7 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
             return reverse('curriculum:unit_pdf', args=[self.curriculum.slug, self.slug])
 
     def get_json_url(self):
-        return reverse('curriculum:stage_element', args=[self.stage_name])
+        return reverse('curriculum:stage_element', args=[self.unit_name])
 
     def get_resources_pdf_url(self):
         return reverse('curriculum:unit_resources_pdf', args=[self.curriculum.slug, self.slug])
@@ -561,7 +561,7 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
 
     @property
     def support_script(self):
-        return "https://studio.code.org/s/%s-support" % getattr(self, 'stage_name', self.slug)
+        return "https://studio.code.org/s/%s-support" % getattr(self, 'unit_name', self.slug)
 
     @property
     def header_corner(self):
@@ -615,8 +615,8 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
         except:
             self.number = self.curriculum.units.count() + 1
 
-        if not self.stage_name:
-            self.stage_name = "%s%d" % (self.curriculum.slug, self.number)
+        if not self.unit_name:
+            self.unit_name = "%s%d" % (self.curriculum.slug, self.number)
 
         super(Unit, self).save(*args, **kwargs)
 

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -372,7 +372,7 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
             return reverse('curriculum:unit_pdf', args=[self.curriculum.slug, self.slug])
 
     def get_json_url(self):
-        return reverse('curriculum:stage_element', args=[self.unit_name])
+        return reverse('curriculum:unit_element', args=[self.unit_name])
 
     def get_resources_pdf_url(self):
         return reverse('curriculum:unit_resources_pdf', args=[self.curriculum.slug, self.slug])

--- a/curricula/serializers.py
+++ b/curricula/serializers.py
@@ -90,7 +90,7 @@ class UnitSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Unit
-        fields = ('title', 'number', 'slug', 'stage_name', 'student_desc', 'teacher_desc', 'lessons')
+        fields = ('title', 'number', 'slug', 'unit_name', 'student_desc', 'teacher_desc', 'lessons')
 
     def get_teacher_desc(self, obj):
         return obj.content
@@ -108,7 +108,7 @@ class UnitLessonsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Unit
-        fields = ('stage_name', 'lessons')
+        fields = ('unit_name', 'lessons')
 
     def get_lessons(self, obj):
         lessons = obj.lessons

--- a/curricula/templatetags/with_unit.py
+++ b/curricula/templatetags/with_unit.py
@@ -9,4 +9,4 @@ def with_unit(value, unit):
     replaces '{{{unit_name}}}' with the specified unit's name as it would
     appear in a url pointing to a script level, e.g. 'coursec-2018'.
     """
-    return value.replace('{{{unit_name}}}', unit.stage_name)
+    return value.replace('{{{unit_name}}}', unit.unit_name)

--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -21,7 +21,7 @@ class CurriculaRenderingTestCase(TestCase):
         self.pl_curriculum = CurriculumFactory(
             slug="pl-curriculum",
             unit_template_override='curricula/pl_unit.html')
-        self.test_unit = UnitFactory(parent=self.test_curriculum, slug="test-unit", stage_name="test-stage-name")
+        self.test_unit = UnitFactory(parent=self.test_curriculum, slug="test-unit", unit_name="test-unit-name")
         self.hoc_unit = UnitFactory(
             parent=self.test_curriculum,
             slug="hoc-unit",
@@ -171,7 +171,7 @@ class CurriculaRenderingTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_metadata_for_unit(self):
-        response = self.client.get('/metadata/test-stage-name.json')
+        response = self.client.get('/metadata/test-unit-name.json')
         self.assertEqual(response.status_code, 200)
 
     def test_get_pdf_url(self):

--- a/curricula/urls.py
+++ b/curricula/urls.py
@@ -23,7 +23,7 @@ urlpatterns = patterns('curricula.views',
                        # JSON Metadata
                        url(r'^metadata/(?P<stage>[-\w]+).json$', views.stage_element, name="stage_element"),
                        url(r'^metadata/course/(?P<slug>[-\w]+).json$', views.curriculum_element, name="curriculum_element"),
-                       url(r'^metadata/(?P<stage>[-\w]+)/standards.json$', views.stage_standards, name="stage_standards"),
+                       url(r'^metadata/(?P<unit_name>[-\w]+)/standards.json$', views.unit_standards, name="unit_standards"),
 
                        # Curriculum URLs
                        url(r'^(?P<slug>[-\w]+)/$', views.curriculum_view, name='curriculum_view'),

--- a/curricula/urls.py
+++ b/curricula/urls.py
@@ -21,7 +21,7 @@ urlpatterns = patterns('curricula.views',
                        url(r'^resolve_feedback/$', views.resolve_feedback, name='resolve_feedback'),
 
                        # JSON Metadata
-                       url(r'^metadata/(?P<stage>[-\w]+).json$', views.stage_element, name="stage_element"),
+                       url(r'^metadata/(?P<unit_name>[-\w]+).json$', views.unit_element, name="unit_element"),
                        url(r'^metadata/course/(?P<slug>[-\w]+).json$', views.curriculum_element, name="curriculum_element"),
                        url(r'^metadata/(?P<unit_name>[-\w]+)/standards.json$', views.unit_standards, name="unit_standards"),
 

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -1064,12 +1064,12 @@ def unit_element(request, slug, unit_slug, format=None):
 
 
 @api_view(['GET', ])
-def stage_element(request, stage, format=None):
+def unit_element(request, unit_name, format=None):
     try:
-        unit = Unit.objects.get(login_required=False, status=2, unit_name=stage)
+        unit = Unit.objects.get(login_required=False, status=2, unit_name=unit_name)
     except MultipleObjectsReturned:
         logger.exception("Warning - found multiple units referencing the unit_name %s" % stage)
-        unit = Unit.objects.filter(login_required=False, status=2, unit_name=stage).first()
+        unit = Unit.objects.filter(login_required=False, status=2, unit_name=unit_name).first()
 
     serializer = UnitSerializer(unit)
     return Response(serializer.data)

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -1068,7 +1068,7 @@ def stage_element(request, stage, format=None):
     try:
         unit = Unit.objects.get(login_required=False, status=2, unit_name=stage)
     except MultipleObjectsReturned:
-        logger.exception("Warning - found multiple units referencing the stage %s" % stage)
+        logger.exception("Warning - found multiple units referencing the unit_name %s" % stage)
         unit = Unit.objects.filter(login_required=False, status=2, unit_name=stage).first()
 
     serializer = UnitSerializer(unit)

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -1066,21 +1066,21 @@ def unit_element(request, slug, unit_slug, format=None):
 @api_view(['GET', ])
 def stage_element(request, stage, format=None):
     try:
-        unit = Unit.objects.get(login_required=False, status=2, stage_name=stage)
+        unit = Unit.objects.get(login_required=False, status=2, unit_name=stage)
     except MultipleObjectsReturned:
         logger.exception("Warning - found multiple units referencing the stage %s" % stage)
-        unit = Unit.objects.filter(login_required=False, status=2, stage_name=stage).first()
+        unit = Unit.objects.filter(login_required=False, status=2, unit_name=stage).first()
 
     serializer = UnitSerializer(unit)
     return Response(serializer.data)
 
 @api_view(['GET', ])
-def stage_standards(request, stage, format=None):
+def unit_standards(request, unit_name, format=None):
     try:
-        unit = Unit.objects.get(login_required=False, status=2, stage_name=stage)
+        unit = Unit.objects.get(login_required=False, status=2, unit_name=unit_name)
     except MultipleObjectsReturned:
-        logger.exception("Warning - found multiple units referencing the stage %s" % stage)
-        unit = Unit.objects.filter(login_required=False, status=2, stage_name=stage).first()
+        logger.exception("Warning - found multiple units referencing the unit %s" % unit_name)
+        unit = Unit.objects.filter(login_required=False, status=2, unit_name=unit_name).first()
 
     serializer = UnitLessonsSerializer(unit)
     return Response(serializer.data)

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -537,12 +537,12 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Filterable):
             return
 
     def get_levels_from_levelbuilder(self):
-        if not hasattr(self.unit, 'stage_name'):
-            return {'error': 'No stage name for unit', 'status': 404}
+        if not hasattr(self.unit, 'unit_name'):
+            return {'error': 'No unit name for unit', 'status': 404}
         else:
             try:
                 url = "https://levelbuilder-studio.code.org/s/%s/stage/%d/summary_for_lesson_plans" % (
-                    self.unit.stage_name, self.number)
+                    self.unit.unit_name, self.number)
                 response = urllib2.urlopen(url)
                 data = json.loads(response.read())
                 self.stage = data
@@ -605,7 +605,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Filterable):
         # Don't try to get stage data on every save.
         try:
             url = "https://levelbuilder-studio.code.org/s/%s/stage/%d/summary_for_lesson_plans" % (
-            self.unit.stage_name, self.number)
+            self.unit.unit_name, self.number)
             response = urllib2.urlopen(url)
             data = json.loads(response.read())
             self.stage = data
@@ -696,7 +696,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Filterable):
     @property
     def code_studio_link(self):
         return "https://studio.code.org/s/%s/stage/%d/puzzle/1/" % (
-            self.unit.stage_name, self.number)
+            self.unit.unit_name, self.number)
 
     @property
     def changelog(self):

--- a/standards/tests/test_standards_rendering.py
+++ b/standards/tests/test_standards_rendering.py
@@ -9,7 +9,7 @@ from standards.factories import StandardFactory, FrameworkFactory, CategoryFacto
 class StandardsRenderingTestCase(TestCase):
     def setUp(self):
         self.test_curriculum = CurriculumFactory(slug="test-curriculum")
-        self.test_unit = UnitFactory(parent=self.test_curriculum, slug="test-unit", stage_name="test-stage-name")
+        self.test_unit = UnitFactory(parent=self.test_curriculum, slug="test-unit", unit_name="test-unit-name")
 
         self.test_framework = FrameworkFactory()
         self.test_category = CategoryFactory()
@@ -33,5 +33,5 @@ class StandardsRenderingTestCase(TestCase):
         self.assertIn('Test Standard', response.content)
 
     def test_standards_metadata_for_unit(self):
-        response = self.client.get('/metadata/test-stage-name/standards.json')
+        response = self.client.get('/metadata/test-unit-name/standards.json')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Units in CurriculumBuilder align with Scripts in Code Studio. For example 'coursea-2019' references a Unit in Curriculum Builder and a Script in Code Studio. 

Lessons in CurriculumBuilder align with Stages in Code Studio, for example "Learn to Drag and Drop". 

While sending standards metadata from CurriculumBuilder to Code Studio, it was noted that the  `stage_name` attribute on CurriculumBuilder Units was erroneously labeled. ([see discussion on Code Studio PR](https://github.com/code-dot-org/code-dot-org/pull/32743#discussion_r367729866)).

This updates `stage_name` to `unit_name` and changes the Unit model to have a `unit_name` attribute that references the `stage_name` column in the database. The end result is that the standards metadata now accurately references `unit_name`.

<img width="752" alt="unit_name" src="https://user-images.githubusercontent.com/12300669/72847529-9d791180-3c57-11ea-8754-7b8e8707e8b2.png">

