### PR TITLE
stage -> unit_name follow up 

### DIFF
--- a/curricula/views.py
+++ b/curricula/views.py
@@ -1068,7 +1068,7 @@ def unit_element(request, unit_name, format=None):
     try:
         unit = Unit.objects.get(login_required=False, status=2, unit_name=unit_name)
     except MultipleObjectsReturned:
-        logger.exception("Warning - found multiple units referencing the unit_name %s" % stage)
+        logger.exception("Warning - found multiple units referencing the unit_name %s" % unit_name)
         unit = Unit.objects.filter(login_required=False, status=2, unit_name=unit_name).first()
 
     serializer = UnitSerializer(unit)


### PR DESCRIPTION
Missed one in #242 which caused errors like: 
<img width="733" alt="Screen Shot 2020-01-23 at 10 17 38 AM" src="https://user-images.githubusercontent.com/12300669/73011931-20ba7480-3dca-11ea-821e-20eee7364446.png">

I renamed "stage" to "unit_name" and the page works now: 
<img width="1104" alt="Screen Shot 2020-01-23 at 10 08 20 AM" src="https://user-images.githubusercontent.com/12300669/73011758-bd304700-3dc9-11ea-964d-a5edd4f2182b.png">


