### PR TITLE
Fix unicode decode error in logging to prevent the i18n sync from crashing

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -476,7 +476,7 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
                 except Exception, e:
                     yield json.dumps(e.message)
                     yield '\n'
-                    logger.exception('Failed to publish %s' % self)
+                    logger.exception(u'Failed to publish %s' % self)
 
     def publish_pdfs(self, silent=False, *args, **kwargs):
         if self.jackfrost_can_build():


### PR DESCRIPTION
The i18n pipeline has been crashing lately. This fix won't fix whatever exception is happening that is putting us into exception handling but will hopefully allow the i18n pipeline to proceed.

Solution from: https://stackoverflow.com/questions/28626984/unicodedecodeerror-when-logging-an-exception-in-python

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
