### PR TITLE
Add nine more languages to CB (none will have PDFs generated)

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -127,20 +127,29 @@ LANGUAGE_CODE_DO_TRANSLATION = "in-tl"
 
 # Supported languages
 LANGUAGES = (
+    ('ar-sa', _('Arabic')),
+    ('de-de', _('German')),
     ('en-us', _('English')),
     ('es-mx', _('Mexican Spanish')),
+    ('fr-fr', _('French')),
+    ('hi-in', _('Hindi')),
     ('it-it', _('Italian')),
-    ('th-th', _('Thai')),
+    ('ja-jp', _('Japanese')),
+    ('ko-kr', _('Korean')),
+    ('ru-ru', _('Russian')),
     ('sk-sk', _('Slovak')),
+    ('th-th', _('Thai')),
+    ('tr-tr', _('Turkish')),
+    ('zh-cn', _('Simplified Chinese')),
+    ('zh-tw', _('Traditional Chinese')),
     (LANGUAGE_CODE_DO_TRANSLATION, _('Translate')),
-    ('hi-in', _('Hindi'))
 )
 
 LANGUAGE_GENERATE_PDF = (
     'es-mx',
     'it-it',
-    'th-th',
     'sk-sk',
+    'th-th',
 )
 
 LOCALE_PATHS = (


### PR DESCRIPTION
[FND-982](https://codedotorg.atlassian.net/browse/FND-982) lists 30 languages to add to the CB sync -- this PR covers the first 10 (Italian is listed on the ticket which is already synced).

I'm breaking this up so that we can monitor for any errors and fix them before enabling more languages.

### Time added
I ran the `publish_i18n` step with PDF generation and without with 6 languages added.

Without PDF generation:
```Publishing 3 models in 6 languages finished in 0:21:07 (average of ~0:03:31 per language)```

With PDF generation on 4 languages:
```Publishing 3 models in 6 languages finished in 3:12:46 (average of ~0:32:07 per language)```

When I ran the sync with out PDF generation with all the newly added languages:
```Publishing 3 models in 15 languages finished in 0:45:49 (average of ~0:03:03 per language)```

These number suggest that each new language _without PDF generation_ will add 3-4 minutes to 
the publish step (there will likely be some added time in the down step as well). This seems like a tolerable amount of time.


## Testing story

Ran the down and out steps locally and tested the site on a handful of languages. No issues.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
