### PR TITLE
Fix translation tag that was broken up onto multiple lines

### DIFF
--- a/curricula/templates/curricula/partials/hoc_lesson_front.html
+++ b/curricula/templates/curricula/partials/hoc_lesson_front.html
@@ -127,8 +127,8 @@
             {% endwith %}
         {% endif %}
         {% if user.is_superuser %}
-            <a href="/admin/lessons/lesson_resources/add/?lesson={{ lesson.pk }}" target="_blank">{% trans 'Add a
-                resource' %}</a>{% endif %}
+            <a href="/admin/lessons/lesson_resources/add/?lesson={{ lesson.pk }}" target="_blank">{% trans 'Add a resource' %}</a>
+        {% endif %}
 
 <!-- Vocab -->
 


### PR DESCRIPTION
Before:
![Screenshot 2020-02-04 at 10 16 26 AM](https://user-images.githubusercontent.com/46464143/73773676-74687e80-4737-11ea-89f6-3163c466a063.png)

After:
![Screenshot 2020-02-04 at 10 15 21 AM](https://user-images.githubusercontent.com/46464143/73773687-77fc0580-4737-11ea-895c-e4783bba6bbb.png)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
