### PR TITLE
add logging to pdf generation path, cleanup code a bit

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -170,7 +170,7 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
     def jackfrost_can_build(self):
         can_build = settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required
         if not can_build:
-            logger.error('jackfrost_can_build returns %s. settings.ENABLE_PUBLISH: %s self.status: %s self.login_required: %s' \
+            logger.warn('jackfrost_can_build returns %s. settings.ENABLE_PUBLISH: %s self.status: %s self.login_required: %s' \
                 % (can_build, settings.ENABLE_PUBLISH, self.status, self.login_required))
         return can_build
 
@@ -463,7 +463,7 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
     def jackfrost_can_build(self):
         can_build = settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required and not self.curriculum.login_required
         if not can_build:
-            logger.error('jackfrost_can_build returns %s. settings.ENABLE_PUBLISH: %s self.status: %s self.login_required: %s self.curriculum.login_required: %s' \
+            logger.warn('jackfrost_can_build returns %s. settings.ENABLE_PUBLISH: %s self.status: %s self.login_required: %s self.curriculum.login_required: %s' \
                 % (can_build, settings.ENABLE_PUBLISH, self.status, self.login_required, self.curriculum.login_required))
         return can_build
 
@@ -722,7 +722,11 @@ class Chapter(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return order
 
     def jackfrost_can_build(self):
-        return settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required
+        can_build = settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required
+        if not can_build:
+            logger.warn('jackfrost_can_build returns %s. settings.ENABLE_PUBLISH: %s self.status: %s self.login_required: %s' \
+                % (can_build, settings.ENABLE_PUBLISH, self.status, self.login_required))
+        return can_build
 
     @property
     def unit(self):

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -166,10 +166,10 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return urls
 
     def jackfrost_can_build(self):
-        can_build = settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required and not self.curriculum.login_required
+        can_build = settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required
         if not can_build:
-            logger.error('jackfrost_can_build returns %s. settings.ENABLE_PUBLISH: %s self.status: %s self.login_required: %s self.curriculum.login_required: %s' \
-                % (can_build, settings.ENABLE_PUBLISH, self.status, self.login_required, self.curriculum.login_required))
+            logger.error('jackfrost_can_build returns %s. settings.ENABLE_PUBLISH: %s self.status: %s self.login_required: %s' \
+                % (can_build, settings.ENABLE_PUBLISH, self.status, self.login_required))
         return can_build
 
     def publish(self, children=False, silent=False):
@@ -457,6 +457,13 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
 
     def pdf_urls(self):
         return [self.get_pdf_url(), self.get_resources_pdf_url()]
+
+    def jackfrost_can_build(self):
+        can_build = settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required and not self.curriculum.login_required
+        if not can_build:
+            logger.error('jackfrost_can_build returns %s. settings.ENABLE_PUBLISH: %s self.status: %s self.login_required: %s self.curriculum.login_required: %s' \
+                % (can_build, settings.ENABLE_PUBLISH, self.status, self.login_required, self.curriculum.login_required))
+        return can_build
 
     def yield_urls_content(self, urls, slack_message_prefix, silent):
         if self.jackfrost_can_build():

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -166,7 +166,11 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return urls
 
     def jackfrost_can_build(self):
-        return settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required
+        can_build = settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required and not self.curriculum.login_required
+        if not can_build:
+            logger.error('jackfrost_can_build returns %s. settings.ENABLE_PUBLISH: %s self.status: %s self.login_required: %s self.curriculum.login_required: %s' \
+                % (can_build, settings.ENABLE_PUBLISH, self.status, self.login_required, self.curriculum.login_required))
+        return can_build
 
     def publish(self, children=False, silent=False):
         if children:
@@ -454,46 +458,31 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
     def pdf_urls(self):
         return [self.get_pdf_url(), self.get_resources_pdf_url()]
 
-    def jackfrost_can_build(self):
-        return settings.ENABLE_PUBLISH and self.status == 2 and not self.login_required and not self.curriculum.login_required
+    def yield_urls_content(self, urls, slack_message_prefix, silent):
+        if self.jackfrost_can_build():
+            for url in urls:
+                read, written = build_single(url)
+                if not silent:
+                    slack_message('slack/message.slack', {
+                        'message': '%s %s %s %s' % (slack_message_prefix, self.content_model, self.title, url),
+                        'color': '#00adbc'
+                    })
+                yield json.dumps(written)
+                yield '\n'
+        else:
+            raise RuntimeError('Unable to generate content: jackfrost cannot build')
 
     def publish(self, children=False, silent=False):
         if children:
             for lesson in self.lesson_set.all():
                 for result in lesson.publish():
                     yield result
-        if self.jackfrost_can_build():
-            for url in self.jackfrost_urls():
-                try:
-                    read, written = build_single(url)
-                    if not silent:
-                        slack_message('slack/message.slack', {
-                            'message': 'published %s %s %s' % (self.content_model, self.title, url),
-                            'color': '#00adbc'
-                        })
-                    yield json.dumps(written)
-                    yield '\n'
-                except Exception, e:
-                    yield json.dumps(e.message)
-                    yield '\n'
-                    logger.exception(u'Failed to publish %s' % self)
+        for content in self.yield_urls_content(self.jackfrost_urls(), 'generated html page: ', silent):
+            yield content
 
     def publish_pdfs(self, silent=False, *args, **kwargs):
-        if self.jackfrost_can_build():
-            for url in self.pdf_urls():
-                try:
-                    read, written = build_single(url)
-                    if not silent:
-                        slack_message('slack/message.slack', {
-                            'message': 'published PDF for %s %s' % (self.content_model, self.title),
-                            'color': '#00adbc'
-                        })
-                    yield json.dumps(written)
-                    yield '\n'
-                except Exception, e:
-                    yield json.dumps(e.message)
-                    yield '\n'
-                    logger.exception('Failed to publish PDF %s' % self)
+        for content in self.yield_urls_content(self.pdf_urls(), 'generated pdf page: ', silent):
+            yield content
 
     def publish_json(self, silent=False, *args, **kwargs):
         if self.jackfrost_can_build():

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -650,53 +650,6 @@ def clone(request):
 
         return HttpResponse(e.message, content_type='application/json', status=500)
 
-
-@staff_member_required
-def old_publish(request):
-    try:
-        pk = int(request.POST.get('pk'))
-
-        page_type = request.POST.get('type')
-
-        if request.POST.get('lessons') == 'true':
-            children = True
-        else:
-            children = False
-
-        klass = globals()[page_type]
-
-        obj = klass.objects.get(pk=pk)
-
-        if request.POST.get('pdf') == 'true':
-            payload = obj.publish_pdfs()
-        else:
-            payload = obj.publish(children=children)
-
-        attachments = [
-            {
-                'color': '#00adbc',
-                'title': 'URL',
-                'text': obj.get_absolute_url(),
-            },
-            {
-                'color': '#00adbc',
-                'title': 'Publishing Details',
-                'text': json.dumps(payload),
-            },
-        ]
-
-        slack_message('slack/message.slack', {
-            'message': 'published %s %s' % (page_type, obj.title),
-            'user': request.user,
-        }, attachments)
-
-    except Exception, e:
-        payload = {'status': 500, 'error': 'failed', 'exception': e.message}
-        logger.exception('Publishing failed')
-
-    return HttpResponse(json.dumps(payload), content_type='application/json', status=payload.get('status', 200))
-
-
 @staff_member_required
 def get_stage_details(request):
     try:

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -19,6 +19,7 @@ from django.core.files.base import ContentFile
 
 # from wkhtmltopdf import WKHtmlToPdf
 from cStringIO import StringIO
+import traceback
 import pdfkit
 import pycurl
 import logging
@@ -388,43 +389,39 @@ def unit_compiled(request, slug, unit_slug):
 
 # @login_required
 def unit_pdf(request, slug, unit_slug):
-
-    buffer = StringIO()
-    c = pycurl.Curl()
-    c.setopt(c.WRITEDATA, buffer)
-
-    unit = get_object_or_404(Unit, curriculum__slug=slug, slug=unit_slug)
-
     try:
+        buffer = StringIO()
+        c = pycurl.Curl()
+        c.setopt(c.WRITEDATA, buffer)
+
+        unit = get_object_or_404(Unit, curriculum__slug=slug, slug=unit_slug)
+
         c.setopt(c.URL, get_url_for_pdf(request, unit.get_compiled_url(), True))
         print unit.get_compiled_url()
         c.perform()
 
         c.close()
         compiled = buffer.getvalue()
-    except Exception:
-        logger.exception('PDF Curling Failed')
-        return HttpResponse('PDF Curling Failed', status=500)
 
-    if request.GET.get('html'):  # Allows testing the html output
-        response = HttpResponse(compiled)
-    else:
-        try:
+        if request.GET.get('html'):  # Allows testing the html output
+            response = HttpResponse(compiled)
+        else:
             pdf = pdfkit.from_string(compiled.decode('utf8'), False, options=settings.WKHTMLTOPDF_CMD_OPTIONS, configuration=pdfkit_config)
-        except Exception:
-            logger.exception('PDF Generation Failed')
-            return HttpResponse('PDF Generation Failed', status=500)
 
-        response = HttpResponse(pdf, content_type='application/pdf')
-        response['Content-Disposition'] = 'inline;filename=unit%s.pdf' % unit.number
+            response = HttpResponse(pdf, content_type='application/pdf')
+            response['Content-Disposition'] = 'inline;filename=unit%s.pdf' % unit.number
 
-        ip = get_real_ip(request)
-        slack_message('slack/message.slack', {
-            'message': 'created a PDF from %s %s' % (slug, unit_slug),
-            'user': request.user.get_username() or ip,
-        })
+            ip = get_real_ip(request)
+            slack_message('slack/message.slack', {
+                'message': 'created a PDF from %s %s' % (slug, unit_slug),
+                'user': request.user.get_username() or ip,
+            })
+            return response
+    except Exception, e:
+        error_message = 'Building Unit PDF Failed: %s' % (traceback.format_exc())
+        logger.exception(error_message)
+        return HttpResponse(error_message, status=500)
 
-    return response
 
 
 def unit_pjspdf(request, slug, unit_slug):
@@ -597,16 +594,17 @@ def publish(request):
             'user': request.user,
         })
 
+
+        response = StreamingHttpResponse(pub_func(children), content_type='text/event-stream')
+
+        # Necessary for nginx to accept streaming response
+
+        response['X-Accel-Buffering'] = 'no'
+
+        return response
     except Exception, e:
-        logger.exception('Publishing failed')
-
+        logger.exception('Publishing failed : %s' % (traceback.format_exc()))
         return HttpResponse(e.message, content_type='application/json', status=500)
-
-    response = StreamingHttpResponse(pub_func(children), content_type='text/event-stream')
-
-    # Necessary for nginx to accept streaming response
-    response['X-Accel-Buffering'] = 'no'
-    return response
 
 
 @staff_member_required


### PR DESCRIPTION
Clean up logging on pdf generation path, to ensure all exceptions make it to application logs. Also, do some minor housekeeping
- move duplicated code between 'publish' and 'publish_pdf' into a seperate function
- add logging for parameters that determine if jackfrost can build, to help us debug issues with content generation due to parameters that could affect this function