### PR TITLE
Make view on site button for maps direct to correct link

### DIFF
--- a/documentation/admin.py
+++ b/documentation/admin.py
@@ -114,6 +114,10 @@ class MapAdmin(PageAdmin, VersionAdmin):
         }),
     )
 
+    # Override the "view on site" button to use local /docs/ instead of slug which does not have /docs
+    def view_on_site(self, obj):
+        return '/docs%s' % obj.get_absolute_url()
+
 
 class BlockDocForm(ModelForm):
     class Meta:


### PR DESCRIPTION
When editing a Map in curriculum builder the View on Site button used to take you to codecurricula.com/concepts/.... with this change it will take you to codecurricula.com/docs/concepts/... which is the correct path. This already happens for IDEs and Block objects but not for Maps.
