### PR TITLE
Fix the links on the docs landing page

### DIFF
--- a/documentation/models.py
+++ b/documentation/models.py
@@ -35,6 +35,9 @@ class IDE(Page, RichText, CloneableMixin):
     def get_absolute_url(self):
         return '/%s/' % self.slug
 
+    def get_relative_url(self):
+        return '%s/' % self.slug
+
     def get_published_url(self):
         return '//studio.code.org/docs/%s/' % self.slug
 

--- a/documentation/templates/documentation/index.html
+++ b/documentation/templates/documentation/index.html
@@ -34,10 +34,10 @@
     <h2>IDEs</h2>
     {% for ide in ides %}
     <ul class="together">
-        <li><h3><a href="{{ide.slug}}">{{ide.title}}</a></h3></li>
+        <li><h3><a href={{ide.get_relative_url}}>{{ide.title}}</a></h3></li>
     </ul>
     {% endfor %}
 
-    <h2><a href="/docs/concepts">Concepts</a></h2>
+    <h2><a href="/docs/concepts/">Concepts</a></h2>
 
 {% endblock %}


### PR DESCRIPTION
The links on studio.code.org/docs are not working because they need the trailing slash at the end to work. This makes that update so that we can generate that page to update it on S3.