### PR TITLE
Remove old styling for tiplinks in guide

### DIFF
--- a/lessons/static/css/commonlesson.css
+++ b/lessons/static/css/commonlesson.css
@@ -443,14 +443,6 @@ html, body{
     padding-left: 10px;
 }
 
-.say .tiplink, .guide .tiplink, .slides .tiplink {
-    margin-left: -35px;
-}
-
-.say ul .tiplink, .guide ul .tiplink, .slides ul .tiplink {
-    margin-left: -55px;
-}
-
 table { border-spacing: 0; }
 
 


### PR DESCRIPTION
In the guide styling on lesson plans the tiplink was still trying to slide to the left. This removes that old styling so tiplinks show in line in the guides like in the rest of the lesson plan.

# Before
<img width="1043" alt="Screen Shot 2020-02-19 at 9 50 42 PM" src="https://user-images.githubusercontent.com/208083/74896268-e361ec00-5361-11ea-8933-9812bb560e46.png">

# After
<img width="488" alt="Screen Shot 2020-02-19 at 9 48 31 PM" src="https://user-images.githubusercontent.com/208083/74896280-e957cd00-5361-11ea-9462-29109f25fc41.png">


