### PR TITLE
Only sync languages that are over 70% translated

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -127,30 +127,12 @@ LANGUAGE_CODE_DO_TRANSLATION = "in-tl"
 
 # Supported languages
 LANGUAGES = (
-    ('ar-sa', _('Arabic')),
-    ('de-de', _('German')),
     ('en-us', _('English')),
-    ('el-gr', _('Greek')),
     ('es-mx', _('Mexican Spanish')),
-    ('fr-fr', _('French')),
     ('hi-in', _('Hindi')),
-    ('hu-hu', _('Hungarian')),
-    ('id-id', _('Indonesian')),
     ('it-it', _('Italian')),
-    ('ja-jp', _('Japanese')),
-    ('ko-kr', _('Korean')),
-    ('ms-my', _('Malay')),
-    ('nl-nl', _('Dutch')),
-    ('ru-ru', _('Russian')),
     ('sk-sk', _('Slovak')),
-    ('sv-se', _('Swedish')),
     ('th-th', _('Thai')),
-    ('tr-tr', _('Turkish')),
-    ('uk-ua', _('Ukranian')),
-    ('ur-pk', _('Urdu')),
-    ('vi-vn', _('Vietnamese')),
-    ('zh-cn', _('Simplified Chinese')),
-    ('zh-tw', _('Traditional Chinese')),
     (LANGUAGE_CODE_DO_TRANSLATION, _('Translate')),
 )
 

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
                     if hasattr(obj, 'publish'):
                         list(obj.publish(silent=True))
                     # Temporary hack to turn off PDF generation while still directing users to the translated pdfs if they exist
-                    if False and language_code in settings.LANGUAGE_GENERATE_PDF and hasattr(obj, 'publish_pdfs'):
+                    if language_code in settings.LANGUAGE_GENERATE_PDF and hasattr(obj, 'publish_pdfs'):
                         pdf_generation_start_time = time.time()
                         list(obj.publish_pdfs(silent=True))
                         pdf_generation_end_time = time.time()


### PR DESCRIPTION
Also:
- Keep the languages we've always synced
- Turn PDF generation back on, but still only for a small list of languages

There's more discussion on [jira](https://codedotorg.atlassian.net/browse/FND-982)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
