### PR TITLE
Catch and log pdf errors in publish_i18n without halting the whole pipeline

### DIFF
--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -56,7 +56,8 @@ class Command(BaseCommand):
                           list(obj.publish_pdfs(silent=True))
                           pdf_generation_end_time = time.time()
                           total_pdf_generation_time += (pdf_generation_end_time - pdf_generation_start_time)
-                        except:
+                        except Exception as e:
+                          log(e)
                           log("PDF publishing failed %s in %s" % (obj.slug, language_code))
                 success_count += 1
 

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -51,10 +51,13 @@ class Command(BaseCommand):
                         list(obj.publish(silent=True))
                     # Temporary hack to turn off PDF generation while still directing users to the translated pdfs if they exist
                     if language_code in settings.LANGUAGE_GENERATE_PDF and hasattr(obj, 'publish_pdfs'):
-                        pdf_generation_start_time = time.time()
-                        list(obj.publish_pdfs(silent=True))
-                        pdf_generation_end_time = time.time()
-                        total_pdf_generation_time += (pdf_generation_end_time - pdf_generation_start_time)
+                        try:
+                          pdf_generation_start_time = time.time()
+                          list(obj.publish_pdfs(silent=True))
+                          pdf_generation_end_time = time.time()
+                          total_pdf_generation_time += (pdf_generation_end_time - pdf_generation_start_time)
+                        except:
+                          log("PDF publishing failed %s in %s" % (obj.slug, language_code))
                 success_count += 1
 
             end_time = time.time()


### PR DESCRIPTION
# Description

There are sometimes pdf publishing issues that are a result of content changes. While we should fix those, I don't think the whole pipeline should halt while we do.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
