### PR TITLE
Fixpdfcb

### DIFF
--- a/bin/generate-pdf.js
+++ b/bin/generate-pdf.js
@@ -1,0 +1,2 @@
+const {getUrlPdfCli} = require('generate-pdf-scripts')
+getUrlPdfCli()

--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -534,7 +534,8 @@ PHANTOMJS_KEY = os.environ.get('PHANTOMJS_KEY')
 AWS_QUERYSTRING_AUTH = False
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
-AWS_STORAGE_BUCKET_NAME = 'cdo-curriculum'
+AWS_SESSION_TOKEN = os.environ.get('AWS_SESSION_TOKEN')
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME') or 'cdo-curriculum'
 # AWS_S3_CUSTOM_DOMAIN = '%s.s3.amazonaws.com' % AWS_STORAGE_BUCKET_NAME
 AWS_S3_CUSTOM_DOMAIN = 'curriculum.code.org'
 AWS_PRELOAD_METADATA = True  # helps collectstatic do updates
@@ -545,11 +546,11 @@ AWS_HEADERS = {
 AWS_BASE_URL = 'http://cdo-curriculum.s3-website-us-east-1.amazonaws.com'
 
 STATICFILES_LOCATION = 'static'
-STATICFILES_STORAGE = 'curriculumBuilder.s3utils.StaticRootS3BotoStorage'
+STATICFILES_STORAGE = 'helpers.s3utils.StaticRootS3BotoStorage'
 STATIC_URL = "https://%s/%s/" % (AWS_S3_CUSTOM_DOMAIN, STATICFILES_LOCATION)
 
 MEDIAFILES_LOCATION = 'media'
-DEFAULT_FILE_STORAGE = 'curriculumBuilder.s3utils.MediaRootS3BotoStorage'
+DEFAULT_FILE_STORAGE = 'helpers.s3utils.MediaRootS3BotoStorage'
 MEDIA_URL = "https://%s/%s/" % (AWS_S3_CUSTOM_DOMAIN, MEDIAFILES_LOCATION)
 
 I18N_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
@@ -585,7 +586,7 @@ FREEZE_INCLUDE_STATIC = False
 # operation which is used for every publish. Disabling preloading here should
 # speed up publishing content by about an order of magnitude.  See
 # https://stackoverflow.com/a/21121924/1810460 for more details.
-JACKFROST_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+JACKFROST_STORAGE = 'helpers.s3utils.S3Boto3StorageSTS'
 JACKFROST_STORAGE_KWARGS = {
     'preload_metadata': False
 }
@@ -660,7 +661,7 @@ CELERY_TIMEZONE = 'America/Los_Angeles'
 # COMPRESS SETTINGS #
 #####################
 
-COMPRESS_STORAGE = 'curriculumBuilder.s3utils.StaticRootS3BotoStorage'
+COMPRESS_STORAGE = 'helpers.s3utils.StaticRootS3BotoStorage'
 COMPRESS_URL = STATIC_URL
 
 ##################

--- a/development_server.py
+++ b/development_server.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import os
+import boto3
+import subprocess
+import urllib
+
+def get_role_credentials():
+  os.environ["AWS_PROFILE"] = "cdo"
+  sts = boto3.client('sts')
+  return sts.assume_role(
+    RoleArn='arn:aws:iam::475661607190:role/admin/Developer',
+    RoleSessionName='role',
+  )
+
+def set_keys_for_child_process(aws_role):
+  os.environ["AWS_ACCESS_KEY_ID"] = aws_role['Credentials']['AccessKeyId']
+  os.environ["AWS_SECRET_ACCESS_KEY"] = aws_role['Credentials']['SecretAccessKey']
+  os.environ["AWS_SESSION_TOKEN"] = aws_role['Credentials']['SessionToken']
+
+def set_resources_for_child_process():
+  os.environ['AWS_STORAGE_BUCKET_NAME'] = 'cdo-curriculum-devel'
+
+set_keys_for_child_process(get_role_credentials())
+set_resources_for_child_process()
+subprocess.call(["python", "manage.py", "runserver_plus"])

--- a/helpers/pdfUtils.py
+++ b/helpers/pdfUtils.py
@@ -13,7 +13,6 @@ def get_pdf_for_url(url):
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
       child = subprocess.call(["node", SCRIPT_PATH, "-w", tmp.name, "-u %s" % (url)])
       contents = tmp.read()
-      tmp.close()
       return contents
   except CalledProcessError, e:
     logger.exception("getting pdf failed for url %s: %s" % (url, e.output))

--- a/helpers/pdfUtils.py
+++ b/helpers/pdfUtils.py
@@ -10,11 +10,10 @@ SCRIPT_PATH = settings.BASE_DIR + "/bin/generate-pdf.js"
 
 def get_pdf_for_url(url):
   try:
-    tmp = tempfile.NamedTemporaryFile(delete=True)
-    child = subprocess.Popen(["node", SCRIPT_PATH, "-w", tmp.name, "-u %s" % (url)], stdout=subprocess.PIPE)
-    child.communicate()
-    contents = tmp.read()
-    tmp.close()
-    return contents
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+      child = subprocess.call(["node", SCRIPT_PATH, "-w", tmp.name, "-u %s" % (url)])
+      contents = tmp.read()
+      tmp.close()
+      return contents
   except CalledProcessError, e:
     logger.exception("getting pdf failed for url %s: %s" % (url, e.output))

--- a/helpers/pdfUtils.py
+++ b/helpers/pdfUtils.py
@@ -1,0 +1,20 @@
+import logging
+import tempfile
+import subprocess
+from django.conf import settings
+from subprocess import CalledProcessError
+
+logger = logging.getLogger(__name__)
+
+SCRIPT_PATH = settings.BASE_DIR + "/bin/generate-pdf.js" 
+
+def get_pdf_for_url(url):
+  try:
+    tmp = tempfile.NamedTemporaryFile(delete=True)
+    child = subprocess.Popen(["node", SCRIPT_PATH, "-w", tmp.name, "-u %s" % (url)], stdout=subprocess.PIPE)
+    child.communicate()
+    contents = tmp.read()
+    tmp.close()
+    return contents
+  except CalledProcessError, e:
+    logger.exception("getting pdf failed for url %s: %s" % (url, e.output))

--- a/helpers/s3utils.py
+++ b/helpers/s3utils.py
@@ -62,6 +62,20 @@ StaticStagingS3BotoStorage = lambda: S3BotoStorageSafe(location='static_staging'
 MediaRootS3BotoStorage = lambda: S3BotoStorageSafe(location='media', file_overwrite=False)
 CurriculumRootS3BotoStorage = lambda: S3BotoStorageSafe(location='curriculum')
 
+# This class is needed for the development_server script to be able to access
+# AWS with supplied credentials. There is a bug in the version of
+# djjango-storages we use (1.6.6), in which the security_token parameter is not picked
+# up from environment variables unless access_key and secret_key are false, in
+# which case all three parameters (access_key, secret_key, and security_token) are
+# picked up from environment variables during object initialization.
+#
+# see:
+#    https://github.com/jschneier/django-storages/issues/282
+#    https://github.com/jschneier/django-storages/blob/9f07eab9c2f86c3d911ec9f6b0f45dca36626bd1/storages/backends/s3boto3.py#L242
+#
+# TODO: When we upgrade django to a version past 1.11, we will be able to
+# upgrade django-storages to a version that does not have this bug, and delete
+# the below class
 class S3Boto3StorageSTS(S3Boto3Storage):
   access_key = False
   secret_key = False

--- a/helpers/s3utils.py
+++ b/helpers/s3utils.py
@@ -1,4 +1,5 @@
 from storages.backends.s3boto import S3BotoStorage, S3BotoStorageFile
+from storages.backends.s3boto3 import S3Boto3Storage
 
 # StaticRootS3BotoStorage = lambda: S3BotoStorage(location='static')
 # MediaRootS3BotoStorage  = lambda: S3BotoStorage(location='media')
@@ -60,3 +61,7 @@ StaticRootS3BotoStorage = lambda: S3BotoStorageSafe(location='static')
 StaticStagingS3BotoStorage = lambda: S3BotoStorageSafe(location='static_staging')
 MediaRootS3BotoStorage = lambda: S3BotoStorageSafe(location='media', file_overwrite=False)
 CurriculumRootS3BotoStorage = lambda: S3BotoStorageSafe(location='curriculum')
+
+class S3Boto3StorageSTS(S3Boto3Storage):
+  access_key = False
+  secret_key = False

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "@code-dot-org/redactable-markdown": "0.3.0"
+    "@code-dot-org/redactable-markdown": "0.3.0",
+    "generate-pdf-scripts": "^2.0.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ beautifulsoup4==4.4.1
 bleach==1.4.2
 # bleach==2.0.0
 boto==2.38.0
+boto3==1.12.8
 celery==3.1.23
 chardet==2.3.0
 collectfast==0.2.3
@@ -40,7 +41,7 @@ django-reversion-compare==0.7.5
 django-slack==5.7.1
 django-smuggler==0.7.0
 django-sortedm2m==1.3.2
-django-storages==1.1.8
+django-storages==1.6.6
 djangorestframework==3.3.1
 djangorestframework-recursive==0.1.1
 docutils


### PR DESCRIPTION
# Description

This should fix PDF generation failing for curriculumbuilder. In this change, we migrate off 
of wkhtmltopdf and onto puppeteer, a library from Google that Winter researched. Using this library,
pdf generation succeeds on pages where it previously failed. 
<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

Test manually. As is, it is difficult to test this feature across the entire site
in an automated way. We will be able to do this easily if we write a PDF generation service.

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
