### PR TITLE
Use short_title in unit calendar if one is supplied

### DIFF
--- a/curricula/templates/curricula/partials/unit_calendar.html
+++ b/curricula/templates/curricula/partials/unit_calendar.html
@@ -15,7 +15,9 @@
                          style="{% if lesson.pacing_weight != None %}flex-grow: {{ lesson.pacing_weight }}; {% endif %}
                                  flex-basis: {{ unit.lesson_width }}%">
                         <span class="lesson-number">{{ lesson.number|stringformat:"02d" }}</span>
-                        <a class="lesson-title" href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">{{ lesson.title }}</a>
+                        <a class="lesson-title" href="{% url 'curriculum:lesson_view' curriculum.slug unit.slug lesson.number %}">
+                            {{ lesson.short_title|default:lesson.title }}
+                        </a>
                         <span class="lesson-icon fa"></span>
                     </div>
                 {% endfor %}


### PR DESCRIPTION
On the Unit Overview page there is a pacing calendar. For really long titles the text was overflowing the space. Josh had already added short_title as a field that was used in the PL session header which is very similar to the calendar on the unit overview page.

This just takes advantage of that field and uses the short_title in the unit calendar if one is supplied.

In the screenshots below look at the difference on Lesson 13.

### Before
<img width="666" alt="Screen Shot 2020-03-03 at 2 37 17 PM" src="https://user-images.githubusercontent.com/208083/75812773-cadbd380-5d5c-11ea-8502-7456cb730189.png">

### After
<img width="679" alt="Screen Shot 2020-03-03 at 2 36 12 PM" src="https://user-images.githubusercontent.com/208083/75812775-cb746a00-5d5c-11ea-8654-392445369a5b.png">

