### PR TITLE
Sync es-es 

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -129,6 +129,7 @@ LANGUAGE_CODE_DO_TRANSLATION = "in-tl"
 LANGUAGES = (
     ('en-us', _('English')),
     ('es-mx', _('Mexican Spanish')),
+    ('es-es', _('Spanish')),
     ('hi-in', _('Hindi')),
     ('it-it', _('Italian')),
     ('sk-sk', _('Slovak')),


### PR DESCRIPTION
Spanish is now synced at 99% so we can start syncing it:
![Screenshot 2020-03-11 at 5 18 28 PM](https://user-images.githubusercontent.com/46464143/76475546-74097600-63bc-11ea-8429-253f468ae8dd.png)

This doesn't add Spanish to the list of languages we generate PDFs for.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
