### PR TITLE
Pull Through For Contained levels only show instructions from the contained level not …

### DIFF
--- a/curricula/templates/curricula/partials/code_studio_pull_through/contained_level.html
+++ b/curricula/templates/curricula/partials/code_studio_pull_through/contained_level.html
@@ -1,0 +1,22 @@
+{% load mezzanine_tags no_autoplay level_link level_embed %}
+
+<div class="instructions-markdown" markdown="1">
+    <h3>Student Instructions</h3>
+    <div class="contained">
+        {% for contained in level.contained_levels %}
+            {{ contained.markdown|richtext_filters|safe }}
+            {{ contained.markdown_instructions|richtext_filters|safe }}
+            {% if contained.parsed_long_instructions %}
+                {{ contained.parsed_long_instructions|richtext_filters|safe }}
+            {% else %}
+                {{ contained.long_instructions|richtext_filters|safe }}
+            {% endif %}
+            <div class="question">
+                {{ contained.questions.0.text|richtext_filters|safe }}
+            </div>
+            {% for answer in contained.answers %}
+                <div class="answer">{{ answer.text|richtext_filters|safe }}</div>
+            {% endfor %}
+        {% endfor %}
+    </div>
+</div>

--- a/curricula/templates/curricula/partials/code_studio_pull_through/level_contents.html
+++ b/curricula/templates/curricula/partials/code_studio_pull_through/level_contents.html
@@ -18,16 +18,21 @@
         </div>
     {% endif %}
 
-    <div class="instructions-markdown" markdown="1">
-        <h3>Student Instructions</h3>
-        {{ level.markdown|richtext_filters|safe }}
-        {{ level.markdown_instructions|richtext_filters|safe }}
-        {% if level.parsed_long_instructions %}
-            {{ level.parsed_long_instructions|richtext_filters|safe }}
-        {% else %}
-            {{ level.long_instructions|richtext_filters|safe }}
-        {% endif %}
-    </div>
+    <!-- Include contained levels for predictions -->
+    {% if level.contained_levels %}
+        {% include "curricula/partials/code_studio_pull_through/contained_level.html" with level=level %}
+    {% else %}
+        <div class="instructions-markdown" markdown="1">
+            <h3>Student Instructions</h3>
+            {{ level.markdown|richtext_filters|safe }}
+            {{ level.markdown_instructions|richtext_filters|safe }}
+            {% if level.parsed_long_instructions %}
+                {{ level.parsed_long_instructions|richtext_filters|safe }}
+            {% else %}
+                {{ level.long_instructions|richtext_filters|safe }}
+            {% endif %}
+        </div>
+    {% endif %}
 
     <!-- Embed video if present -->
     {% if level.type == "StandaloneVideo" and not pdf%}
@@ -52,22 +57,6 @@
     <div class="curriculum-reference">
         <iframe frameborder="0" class="map-embed" src="{{ level.reference|level_embed }}" width="100%" height="500"></iframe>
     </div>
-    {% endif %}
-
-    <!-- Include contained levels for predictions -->
-    {% if level.contained_levels %}
-        <div class="contained">
-            {% for contained in level.contained_levels %}
-                {{ contained.markdown_instructions|richtext_filters|safe }}
-                {{ contained.long_instructions|richtext_filters|safe }}
-                <div class="question">
-                    {{ contained.questions.0.text|richtext_filters|safe }}
-                </div>
-                {% for answer in contained.answers %}
-                    <div class="answer">{{ answer.text|richtext_filters|safe }}</div>
-                {% endfor %}
-            {% endfor %}
-        </div>
     {% endif %}
 
     {% if level.type == "BubbleChoice" %}

--- a/curricula/templates/curricula/partials/code_studio_pull_through/level_contents_sublevel.html
+++ b/curricula/templates/curricula/partials/code_studio_pull_through/level_contents_sublevel.html
@@ -18,16 +18,21 @@
         </div>
     {% endif %}
 
-    <div class="instructions-markdown" markdown="1">
-        <h3>Student Instructions</h3>
-        {{ sublevel.markdown|richtext_filters|safe }}
-        {{ sublevel.markdown_instructions|richtext_filters|safe }}
-        {% if sublevel.parsed_long_instructions %}
-            {{ sublevel.parsed_long_instructions|richtext_filters|safe }}
-        {% else %}
-            {{ sublevel.long_instructions|richtext_filters|safe }}
-        {% endif %}
-    </div>
+    <!-- Include contained levels for predictions -->
+    {% if sublevel.contained_levels %}
+        {% include "curricula/partials/code_studio_pull_through/contained_level.html" with level=sublevel %}
+    {% else %}
+        <div class="instructions-markdown" markdown="1">
+            <h3>Student Instructions</h3>
+            {{ sublevel.markdown|richtext_filters|safe }}
+            {{ sublevel.markdown_instructions|richtext_filters|safe }}
+            {% if sublevel.parsed_long_instructions %}
+                {{ sublevel.parsed_long_instructions|richtext_filters|safe }}
+            {% else %}
+                {{ sublevel.long_instructions|richtext_filters|safe }}
+            {% endif %}
+        </div>
+    {% endif %}
 
         <!-- Embed video if present -->
     {% if sublevel.type == "StandaloneVideo" and not pdf%}
@@ -54,19 +59,4 @@
     </div>
     {% endif %}
 
-    <!-- Include contained levels for predictions -->
-    {% if sublevel.contained_levels %}
-        <div class="contained">
-            {% for contained in sublevel.contained_levels %}
-                {{ contained.markdown_instructions|richtext_filters|safe }}
-                {{ contained.long_instructions|richtext_filters|safe }}
-                <div class="question">
-                    {{ contained.questions.0.text|richtext_filters|safe }}
-                </div>
-                {% for answer in contained.answers %}
-                    <div class="answer">{{ answer.text|richtext_filters|safe }}</div>
-                {% endfor %}
-            {% endfor %}
-        </div>
-    {% endif %}
 </div>

--- a/curricula/templates/curricula/partials/code_studio_pull_through/level_sfmd_contents.html
+++ b/curricula/templates/curricula/partials/code_studio_pull_through/level_sfmd_contents.html
@@ -7,13 +7,16 @@
         <span class="level-link-icon fa"></span>
     </a>
 
-    <div class="instructions-markdown">
-
-        {{ level.markdown|richtext_filters|safe }}
-        {{ level.markdown_instructions|richtext_filters|safe }}
-        {{ level.long_instructions|richtext_filters|safe }}
-
-    </div>
+    <!-- Include contained levels for predictions -->
+    {% if level.contained_levels %}
+        {% include "curricula/partials/code_studio_pull_through/contained_level.html" with level=level %}
+    {% else %}
+        <div class="instructions-markdown">
+            {{ level.markdown|richtext_filters|safe }}
+            {{ level.markdown_instructions|richtext_filters|safe }}
+            {{ level.long_instructions|richtext_filters|safe }}
+        </div>
+    {% endif %}
 
     <!-- Embed video if present -->
     {% if level.type == "StandaloneVideo" and not pdf%}
@@ -28,21 +31,5 @@
     <div class="curriculum-reference">
         <iframe frameborder="0" class="map-embed" src="{{ level.reference|level_embed }}" width="100%" height="500"></iframe>
     </div>
-    {% endif %}
-
-    <!-- Include contained levels for predictions -->
-    {% if level.contained_levels %}
-        <div class="contained">
-            {% for contained in level.contained_levels %}
-                {{ contained.markdown_instructions|richtext_filters|safe }}
-                {{ contained.long_instructions|richtext_filters|safe }}
-                <div class="question">
-                    {{ contained.questions.0.text|richtext_filters|safe }}
-                </div>
-                {% for answer in contained.answers %}
-                    <div class="answer">{{ answer.text|richtext_filters|safe }}</div>
-                {% endfor %}
-            {% endfor %}
-        </div>
     {% endif %}
 </div>


### PR DESCRIPTION
[Jira](https://codedotorg.atlassian.net/browse/PLAT-63)

Contained levels have a parent and child level. The instructions from the parent level should not show in the code studio pull through and all the instructions from the child level should. 

Fixed two issues: 
1. The instructions from the parent were showing in the pull through
2. Some of the instructions were not showing (specially things saved as 'markdown')

Example Level: https://levelbuilder-studio.code.org/s/csd3-2019/stage/11/puzzle/2 (I added long instructions on the parent that said 'Testing that this does not show on lesson')

## Before

![Screen Shot 2020-04-01 at 3 18 00 PM](https://user-images.githubusercontent.com/208083/78177917-ddfdc400-742c-11ea-9142-b9ff5dc719d8.png)

## After

![Screen Shot 2020-04-01 at 3 20 47 PM](https://user-images.githubusercontent.com/208083/78177935-e2c27800-742c-11ea-94a7-cc0b72019bf3.png)

