### PR TITLE
Pin version 2.10.6 of redis to fix auto deploy issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -90,3 +90,4 @@ whitenoise==2.0
 wsgiref==0.1.2
 ddt==1.1.3
 unittest2==1.1.0
+redis==2.10.6


### PR DESCRIPTION
Auto deploy failed with error "Invalid input of type: 'CacheKey'. Convert to a bytes, string, int or float first.". Dave traced the issue down looking at: it looks like it has to do with the version of redis: https://github.com/jazzband/django-redis/issues/342. He found that https://github.com/jazzband/django-redis/blob/master/requirements.txt will take any latest version of redis. So even though we pin our version, they do not pin theirs. So pinning a redis version lesson that 3 should fix based on: https://stackoverflow.com/questions/53331405/django-compress-error-invalid-input-of-type-cachekey/53336728#53336728
