### PR TITLE
Fix creative commons banner for non-lesson pages

### DIFF
--- a/curricula/templates/curricula/partials/footer.html
+++ b/curricula/templates/curricula/partials/footer.html
@@ -4,7 +4,11 @@
 <footer>
   <div class="container">
     <div class="row">
-      <a href="https://creativecommons.org/"><img src="{% static lesson.creative_commons_image %}" border="0"></a><br/>
+      {% if lesson %}
+        <a href="https://creativecommons.org/"><img src="{% static lesson.creative_commons_image %}" border="0"></a><br/>
+      {% else %}
+        <a href="https://creativecommons.org/"><img src="{% static "img/creativeCommons-by-nc-sa.png" %}" border="0"></a><br/>
+      {% endif %}
       <span class="license">{{ license|richtext_filters|safe }}</span>
     </div>
   </div>


### PR DESCRIPTION
ef493c6ba52c67960f1e4525cbfdd2b9b2a1d894 introduced a regression, where the
creative commons banner broke on all pages that are not lesson pages. This PR
fixes this regression

# Description

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


- [jira](https://codedotorg.atlassian.net/browse/LP-1283)

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
