### PR TITLE
log errors in the i18n sync out

### DIFF
--- a/i18n/management/commands/i18n_sync_down.py
+++ b/i18n/management/commands/i18n_sync_down.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
                     '-p', plugins
                 ])
 
-        # Compile Django translations
+        log("Compiling Django translations")
         management.call_command("compilemessages")
 
     def upload_translations(self):
@@ -75,6 +75,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         log("I18n Sync Step 3 of 4: Download and process translations")
-        self.download_translations()
-        self.restore_translations()
-        self.upload_translations()
+        try:
+            self.download_translations()
+            self.restore_translations()
+            self.upload_translations()
+        except Exception as err:
+            log(err)
+            raise


### PR DESCRIPTION
# Description

Some [bad translations](https://crowdin.com/translate/curriculumbuilder/22478/en-it#2066606) in the curriculumbuilder project broke the sync out a while back. Unfortunately, the only thing logged was "[ERROR: I18n Sync encountered a problem and did not complete](https://codedotorg.slack.com/archives/C0SUN2VT5/p1586416862303900)". With this change, we will also log the content of the error itself to make future debugging easier.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
