### PR TITLE
Override locale middleware

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -132,6 +132,7 @@ LANGUAGES = (
     ('es-es', _('Spanish')),
     ('hi-in', _('Hindi')),
     ('it-it', _('Italian')),
+    ('pl-pl', _('Polish')),
     ('sk-sk', _('Slovak')),
     ('th-th', _('Thai')),
     (LANGUAGE_CODE_DO_TRANSLATION, _('Translate')),
@@ -346,14 +347,13 @@ TEMPLATES = [{u'APP_DIRS': False,
 # these middleware classes will be applied in the order given, and in the
 # response phase the middleware will be applied in reverse order.
 MIDDLEWARE_CLASSES = (
-    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.gzip.GZipMiddleware',
     # 'debug_toolbar.middleware.DebugToolbarMiddleware',
     "mezzanine.core.middleware.UpdateCacheMiddleware",
     'django.contrib.sessions.middleware.SessionMiddleware',
-    # Uncomment if using internationalisation or localisation
-    # 'django.middleware.locale.LocaleMiddleware',
+    'i18n.middleware.StrictLocaleMiddleware',
     'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -353,7 +353,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'i18n.middleware.StrictLocaleMiddleware',
     'corsheaders.middleware.CorsMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/i18n/middleware.py
+++ b/i18n/middleware.py
@@ -1,0 +1,36 @@
+import re
+import warnings
+
+from django.conf import settings
+from django.utils import translation
+from django.http import HttpResponseRedirect
+from django.middleware.locale import LocaleMiddleware
+
+def get_language_from_path_strict(path, allowed_languages):
+    language_code_prefix_re = re.compile(r'^/([\w-]+)(/|$)')
+    regex_match = language_code_prefix_re.match(path)
+    if not regex_match:
+        return settings.LANGUAGE_CODE
+    lang_code = regex_match.group(1)
+    if lang_code not in allowed_languages:
+        return settings.LANGUAGE_CODE
+    return lang_code
+
+class StrictLocaleMiddleware(LocaleMiddleware):
+
+    def __init__(self):
+        super(StrictLocaleMiddleware, self).__init__()
+        self.language_codes = [
+            language_code for language_code, _ in settings.LANGUAGES
+            if language_code != settings.LANGUAGE_CODE
+        ]
+
+    # See https://github.com/django/django/blob/6a0dc2176f4ebf907e124d433411e52bba39a28e/django/middleware/locale.py#L29
+    # for the original implementation
+    # This function simply checks for the language of the request by only looking at the URL.
+    # It also requires an exact language match in order to set the language (see above)
+    def process_request(self, request):
+        language = get_language_from_path_strict(
+                request.path_info, self.language_codes)
+        translation.activate(language)
+        request.LANGUAGE_CODE = translation.get_language()

--- a/i18n/middleware.py
+++ b/i18n/middleware.py
@@ -1,23 +1,22 @@
 import re
-import warnings
 
 from django.conf import settings
 from django.utils import translation
-from django.http import HttpResponseRedirect
 from django.middleware.locale import LocaleMiddleware
 
 def get_language_from_path_strict(path, allowed_languages):
-    language_code_prefix_re = re.compile(r'^/([\w-]+)(/|$)')
-    regex_match = language_code_prefix_re.match(path)
-    if not regex_match:
-        return settings.LANGUAGE_CODE
-    lang_code = regex_match.group(1)
-    if lang_code not in allowed_languages:
-        return settings.LANGUAGE_CODE
-    return lang_code
+    for language_code in allowed_languages:
+        if path.startswith('/{}/'.format(language_code)):
+            return language_code
+    return settings.LANGUAGE_CODE
 
 class StrictLocaleMiddleware(LocaleMiddleware):
-
+    """
+    See https://github.com/django/django/blob/6a0dc2176f4ebf907e124d433411e52bba39a28e/django/middleware/locale.py#L29
+    for the original implementation
+    This function simply checks for the language of the request by only looking at the URL.
+    It also requires an exact language match in order to set the language (see above)
+    """
     def __init__(self):
         super(StrictLocaleMiddleware, self).__init__()
         self.language_codes = [
@@ -25,10 +24,6 @@ class StrictLocaleMiddleware(LocaleMiddleware):
             if language_code != settings.LANGUAGE_CODE
         ]
 
-    # See https://github.com/django/django/blob/6a0dc2176f4ebf907e124d433411e52bba39a28e/django/middleware/locale.py#L29
-    # for the original implementation
-    # This function simply checks for the language of the request by only looking at the URL.
-    # It also requires an exact language match in order to set the language (see above)
     def process_request(self, request):
         language = get_language_from_path_strict(
                 request.path_info, self.language_codes)

--- a/i18n/tests/test_url_resolver.py
+++ b/i18n/tests/test_url_resolver.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from django.contrib.auth.models import Permission
+from django.utils import translation
+
+from curricula.factories import UserFactory, CurriculumFactory, UnitFactory
+from lessons.factories import LessonFactory, ResourceFactory, ActivityFactory
+from django.conf import settings
+
+class I18nUrlResolverTestCase(TestCase):
+    def setUp(self):
+        self.csf_curriculum = CurriculumFactory(
+            slug="csf-curriculum",
+            unit_template_override='curricula/csf_unit.html')
+        self.pl_curriculum = CurriculumFactory(
+            slug="pl-curriculum",
+            unit_template_override='curricula/pl_unit.html')
+        self.csf_unit = UnitFactory(
+            parent=self.csf_curriculum,
+            slug="csf-unit",
+            lesson_template_override="curricula/csf_lesson.html")
+        self.pl_unit = UnitFactory(
+            parent=self.pl_curriculum,
+            slug="pl-unit",
+            lesson_template_override="curricula/pl_lesson.html")
+
+    def test_render_curriculum(self):
+        response = self.client.get('/csf-curriculum/')
+        self.assertEqual(response.status_code, 200)
+        for language_code, _ in settings.LANGUAGES:
+            response = self.client.get('/%s/csf-curriculum/' % language_code)
+            self.assertEqual(response.status_code, 200, "failed for language %s" % language_code)
+            self.assertEqual(language_code, translation.get_language())
+
+    def test_pl_lesson(self):
+        response = self.client.get('/pl-curriculum/pl-unit/')
+        self.assertEqual(response.status_code, 200)

--- a/i18n/tests/test_url_resolver.py
+++ b/i18n/tests/test_url_resolver.py
@@ -5,16 +5,16 @@ from django.utils import translation
 from curricula.factories import UserFactory, CurriculumFactory, UnitFactory
 from lessons.factories import LessonFactory, ResourceFactory, ActivityFactory
 from django.conf import settings
+from mock import patch, Mock
 
+
+@patch('i18n.utils.I18nFileWrapper.get_translated_field', Mock())
 class I18nUrlResolverTestCase(TestCase):
     def setUp(self):
         self.csf_curriculum = CurriculumFactory(
             slug="csf-curriculum",
             unit_template_override='curricula/csf_unit.html')
-        self.csf_unit = UnitFactory(
-            parent=self.csf_curriculum,
-            slug="csf-unit",
-            lesson_template_override="curricula/csf_lesson.html")
+
         # URLs that start with a language prefix (in this case Polish)
         # don't work by default in Django. Check that they do in our system.
         self.pl_curriculum = CurriculumFactory(
@@ -32,7 +32,11 @@ class I18nUrlResolverTestCase(TestCase):
             response = self.client.get('/%s/csf-curriculum/' % language_code)
             self.assertEqual(response.status_code, 200, "failed for language %s" % language_code)
             self.assertEqual(language_code, translation.get_language())
+        # Unfortunately, other tests assume that the language activated will be English
+        # so let's clean up after ourselves.
+        translation.activate(settings.LANGUAGE_CODE)
 
     def test_pl_lesson(self):
         response = self.client.get('/pl-curriculum/pl-unit/')
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(settings.LANGUAGE_CODE, translation.get_language())

--- a/i18n/tests/test_url_resolver.py
+++ b/i18n/tests/test_url_resolver.py
@@ -11,13 +11,15 @@ class I18nUrlResolverTestCase(TestCase):
         self.csf_curriculum = CurriculumFactory(
             slug="csf-curriculum",
             unit_template_override='curricula/csf_unit.html')
-        self.pl_curriculum = CurriculumFactory(
-            slug="pl-curriculum",
-            unit_template_override='curricula/pl_unit.html')
         self.csf_unit = UnitFactory(
             parent=self.csf_curriculum,
             slug="csf-unit",
             lesson_template_override="curricula/csf_lesson.html")
+        # URLs that start with a language prefix (in this case Polish)
+        # don't work by default in Django. Check that they do in our system.
+        self.pl_curriculum = CurriculumFactory(
+            slug="pl-curriculum",
+            unit_template_override='curricula/pl_unit.html')
         self.pl_unit = UnitFactory(
             parent=self.pl_curriculum,
             slug="pl-unit",

--- a/i18n/tests/test_url_resolver.py
+++ b/i18n/tests/test_url_resolver.py
@@ -25,6 +25,11 @@ class I18nUrlResolverTestCase(TestCase):
             slug="pl-unit",
             lesson_template_override="curricula/pl_lesson.html")
 
+    def tearDown(self):
+        # Unfortunately, other tests assume that the language activated will be English
+        # so let's clean up after ourselves.
+        translation.activate(settings.LANGUAGE_CODE)
+
     def test_render_curriculum(self):
         response = self.client.get('/csf-curriculum/')
         self.assertEqual(response.status_code, 200)
@@ -32,9 +37,6 @@ class I18nUrlResolverTestCase(TestCase):
             response = self.client.get('/%s/csf-curriculum/' % language_code)
             self.assertEqual(response.status_code, 200, "failed for language %s" % language_code)
             self.assertEqual(language_code, translation.get_language())
-        # Unfortunately, other tests assume that the language activated will be English
-        # so let's clean up after ourselves.
-        translation.activate(settings.LANGUAGE_CODE)
 
     def test_pl_lesson(self):
         response = self.client.get('/pl-curriculum/pl-unit/')


### PR DESCRIPTION
# Description

Django documentation a lot of this work was based on is [here](https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#how-django-discovers-language-preference)

In the past, we've attempted to sync Polish but it caused problems because `/pl-sandbox/` resolved to be in Polish. It turns out that Django automatically uses the "base language" if it can't find the locale, so Django thought `sandbox` was a locale. This PR overrides that logic to only use the URL locale if it is an exact match to one we have enabled.

I rearranged the order of the middleware to be in line with the above documentation and because it wasn't working before I moved the `StrictLocaleMiddleware` to be after `SessionMiddleware`.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-997)

## Testing story
- Added a unit test. 
- Manually tested `/pl-sandbox/csd_q1_and_q2/`, `/csf-1718/coursea/`, and `/es-mx/csf-1718/coursea/` to ensure they all still worked at intended

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
