### PR TITLE
Make sure we use the simpleDef for CSF courses

### DIFF
--- a/curricula/templates/curricula/partials/lesson_front.html
+++ b/curricula/templates/curricula/partials/lesson_front.html
@@ -153,7 +153,11 @@
             <h2>{% trans 'Vocabulary' %}</h2>
             <ul>
                 {% for word in lesson.vocab.all %}
-                    <li><strong>{{ word.word }}</strong> - {{ word.detailDef }}</li>
+                    {% if 'CS Fundamentals' in lesson.curriculum.title %}
+                        <li><strong>{{ word.word }}</strong> - {{ word.simpleDef }}</li>
+                    {% else %}
+                        <li><strong>{{ word.word }}</strong> - {{ word.detailDef }}</li>
+                    {% endif %}
                 {% endfor %}
             </ul>
         {% endif %}

--- a/curricula/templates/curricula/partials/vocab_list.html
+++ b/curricula/templates/curricula/partials/vocab_list.html
@@ -10,7 +10,11 @@
             <ul>
 
                 {% for vocab in lesson.vocab.all %}
-                    <li><span class="vocab-word">{{ vocab.word }}</span>: {{ vocab.detailDef }}</li>
+                    {% if 'CS Fundamentals' in lesson.curriculum.title %}
+                      <li><span class="vocab-word">{{ vocab.word }}</span>: {{ vocab.simpleDef }}</li>
+                    {% else %}
+                      <li><span class="vocab-word">{{ vocab.word }}</span>: {{ vocab.detailDef }}</li>
+                    {% endif %}
                 {% endfor %}
             </ul>
             </div>


### PR DESCRIPTION

Mike reported that the CSP/CSD definition was showing up on CSF courses. I'm not sure when we stopped using the simple definition but I put this temporary fix in until we move vocab over to Code Studio and make it per course.

## Lesson Page

| Before | After |
| -- | -- |
| ![Screen Shot 2020-04-30 at 4 14 01 PM](https://user-images.githubusercontent.com/208083/80754766-9cc90480-8afd-11ea-9bd7-1bd9c1b954be.png) | ![Screen Shot 2020-04-30 at 4 13 14 PM](https://user-images.githubusercontent.com/208083/80754720-815df980-8afd-11ea-922f-b3b084844522.png) |

## Vocab Page

| Before | After |
| -- | -- |
| ![Screen Shot 2020-04-30 at 4 10 06 PM](https://user-images.githubusercontent.com/208083/80754658-67bcb200-8afd-11ea-9286-c88c661eec21.png) | ![Screen Shot 2020-04-30 at 4 10 13 PM](https://user-images.githubusercontent.com/208083/80754662-68554880-8afd-11ea-95ca-59ed66d4e353.png) |