### PR TITLE
add a URI for doclinks and update markdown to simply generate a link to that URI

### DIFF
--- a/curriculumBuilder/doclinks.py
+++ b/curriculumBuilder/doclinks.py
@@ -1,75 +1,30 @@
-from django.db.models import Q
-
-import re
+import urllib
 
 from markdown.extensions import Extension
 from markdown.inlinepatterns import Pattern
 from markdown.util import etree
 
-from documentation.models import Block
-
 DOC_RE = r'(\`)((?P<ide>\w*?)\/)*(?P<block>.*?)(\`)'
 
 
-class AttrTagPattern(Pattern):
-    """
-    Return element of type `tag` with a text attribute of group(3)
-    of a Pattern and with the html attributes defined with the constructor.
-
-    """
-
-    def __init__(self, pattern, tag, attrs):
-        Pattern.__init__(self, pattern)
-        self.tag = tag
-        self.attrs = attrs
-
+class DoclinkPattern(Pattern):
     def handleMatch(self, m):
-        el = etree.Element(self.tag)
-        el.text = m.group(3)
-
-        block = None
-        block_full = m.group('block')
-        block_alphanum = re.sub(r'[\(|\{].*[\)|\}\;]', '', m.group('block'))
-
-        if m.group('ide'):
-            try:
-                block = Block.objects.get(parent_ide__slug=m.group('ide'), slug=block_full)
-            except Block.DoesNotExist:
-                try:
-                    print("Block with IDE not found, trying by title")
-                    block = Block.objects.get(parent_ide__slug=m.group('ide'), title=block_full)
-                except Block.DoesNotExist:
-                    print("Block with IDE not found, trying with alphanum only")
-                    block = Block.objects.filter(Q(parent_ide__slug=m.group('ide'), slug=block_alphanum) |
-                                                 Q(parent_ide__slug=m.group('ide'), title=block_alphanum)).first()
-
-        if not block:
-            block = Block.objects.filter(Q(slug=block_full) | Q(title=block_full)).first()
-            if not block:
-                block = Block.objects.filter(Q(slug=block_alphanum) | Q(title=block_alphanum)).first()
-
-        if block:
-            el.set('class', 'block')
-            el.set('style', 'background-color: %s;' % block.parent_cat.color)
-            el.text = "<a href='%s'>%s</a>" % (block.get_published_url(), self.escape(m.group('block')))
-        else:
-            el.text = "%s%s" % (m.group('ide') or '', self.escape(m.group('block')) or '')
-
-        for (key, val) in self.attrs.items():
-            el.set(key, val)
+        el = etree.Element("a")
+        # we could use django to build these urls more robustly, but since we
+        # want to convert this to a clientside renderer anyway, I'm inclined to
+        # keep it super simple for now.
+        href = "/docs/doclink"
+        if (m.group('ide')):
+            href += "/{}".format(m.group('ide'))
+        href += "/{}".format(m.group('block'))
+        href = urllib.quote(href)
+        el.set('href', href)
         return el
-
-    def escape(self, html):
-        """ Basic html escaping """
-        html = html.replace('&', '&amp;')
-        html = html.replace('<', '&lt;')
-        html = html.replace('>', '&gt;')
-        return html.replace('"', '&quot;')
 
 
 class DocLinksExtensions(Extension):
     def extendMarkdown(self, md, md_globals):
-        doc_tag = AttrTagPattern(DOC_RE, 'code', {})
+        doc_tag = DoclinkPattern(DOC_RE)
         md.inlinePatterns.add('block', doc_tag, '_begin')
 
 

--- a/documentation/urls.py
+++ b/documentation/urls.py
@@ -12,5 +12,8 @@ urlpatterns = [
         url(r'^(?P<slug>[-\w]+lab)/$', views.ide_view, name='ide_view'),
         url(r'^(?P<ide_slug>[-\w]+lab)/(?P<slug>[-\w.]+)/$', views.block_view, name='block_view'),
         url(r'^(?P<ide_slug>[-\w]+lab)/(?P<slug>[-\w.]+)/embed/$', views.embed_view, name='embed_view'),
+
+        # generic route for doclinks
+        url(r'^doclink/((?P<ide>\w*?)\/)*(?P<slug>.*?)/$', views.doclink_view, name='doclink_view'),
     )
 ]


### PR DESCRIPTION
so we can use clientside rather than serverside markdown

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
