### PR TITLE
Hide iframe for w3schools documentation

### DIFF
--- a/documentation/templates/documentation/partials/block.html
+++ b/documentation/templates/documentation/partials/block.html
@@ -166,7 +166,12 @@
 {% if code_block.ext_doc %}
     <div id="external_doc">
         <h2>Additional Information</h2>
-        <p>From <a href="{{ code_block.ext_doc }}" taraget="_blank">{{ code_block.ext_doc }}</a></p>
-        <iframe src="{{ code_block.ext_doc }}" width="100%" height="1000px" frameborder="none"></iframe>
+				<!-- dont render iframe for w3schools content, see https://codedotorg.atlassian.net/browse/LP-1424 -->
+    		{% if 'w3schools' in code_block.ext_doc %} 
+        	<p>For more information, see <a href="{{ code_block.ext_doc }}" taraget="_blank">{{ code_block.ext_doc }}</a></p>
+				{% else %}
+        	<p>From <a href="{{ code_block.ext_doc }}" taraget="_blank">{{ code_block.ext_doc }}</a></p>
+        	<iframe src="{{ code_block.ext_doc }}" width="100%" height="1000px" frameborder="none"></iframe>
+				{% endif %}
     </div>
 {% endif %}

--- a/documentation/templates/documentation/partials/block.html
+++ b/documentation/templates/documentation/partials/block.html
@@ -166,11 +166,11 @@
 {% if code_block.ext_doc %}
     <div id="external_doc">
         <h2>Additional Information</h2>
-        <!-- dont render iframe for w3schools content, see https://codedotorg.atlassian.net/browse/LP-1424 -->
+        <!-- dont render iframe for w3schools content, see https://github.com/code-dot-org/curriculumbuilder/pull/283 -->
         {% if 'w3schools' in code_block.ext_doc %} 
-          <p>For more information, see <a href="{{ code_block.ext_doc }}" taraget="_blank">{{ code_block.ext_doc }}</a></p>
+          <p>For more information, see <a href="{{ code_block.ext_doc }}" target="_blank">{{ code_block.ext_doc }}</a></p>
         {% else %}
-          <p>From <a href="{{ code_block.ext_doc }}" taraget="_blank">{{ code_block.ext_doc }}</a></p>
+          <p>From <a href="{{ code_block.ext_doc }}" target="_blank">{{ code_block.ext_doc }}</a></p>
           <iframe src="{{ code_block.ext_doc }}" width="100%" height="1000px" frameborder="none"></iframe>
         {% endif %}
     </div>

--- a/documentation/templates/documentation/partials/block.html
+++ b/documentation/templates/documentation/partials/block.html
@@ -166,12 +166,12 @@
 {% if code_block.ext_doc %}
     <div id="external_doc">
         <h2>Additional Information</h2>
-				<!-- dont render iframe for w3schools content, see https://codedotorg.atlassian.net/browse/LP-1424 -->
-    		{% if 'w3schools' in code_block.ext_doc %} 
-        	<p>For more information, see <a href="{{ code_block.ext_doc }}" taraget="_blank">{{ code_block.ext_doc }}</a></p>
-				{% else %}
-        	<p>From <a href="{{ code_block.ext_doc }}" taraget="_blank">{{ code_block.ext_doc }}</a></p>
-        	<iframe src="{{ code_block.ext_doc }}" width="100%" height="1000px" frameborder="none"></iframe>
-				{% endif %}
+        <!-- dont render iframe for w3schools content, see https://codedotorg.atlassian.net/browse/LP-1424 -->
+        {% if 'w3schools' in code_block.ext_doc %} 
+          <p>For more information, see <a href="{{ code_block.ext_doc }}" taraget="_blank">{{ code_block.ext_doc }}</a></p>
+        {% else %}
+          <p>From <a href="{{ code_block.ext_doc }}" taraget="_blank">{{ code_block.ext_doc }}</a></p>
+          <iframe src="{{ code_block.ext_doc }}" width="100%" height="1000px" frameborder="none"></iframe>
+        {% endif %}
     </div>
 {% endif %}


### PR DESCRIPTION
See https://codedotorg.atlassian.net/browse/LP-1424

From zendesk - A user reported that w3schools pages were not showing up in iframes on our documentation site, rendering an empty white box where a page used to appear.

The error outlined by the user is due to w3schools setting the X-Frame-Options header in HTTP responses to requests to their site to DENY. In english, this means that they are explicitly forbidding browsers from showing content from their site inside of iframes, as we are doing. Websites often do this in order to stop clickjacking attacks - sites posing as impostors of their site using iframes, for malicious purposes. If interested you can read more about this here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options and here: https://en.wikipedia.org/wiki/Clickjacking. My guess is that when we first made these pages, w3schools had not done this on their end.

Since there is nothing we can do to have this content appear on our webpage, I letsremove these frames pointing to w3schools. We can leave the link for users to follow. If we want content on our own pages that mirrors what is on w3schools, we'll need to host it ourselves.

We do have some pages in curriculumbuilder that render documentation for non-w3schools pages: I'm keeping those for now, but we may want to consider migrating off of the iframe pattern for everyone. Who knows when our other dependencies decide to forbid  embedding?

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1424)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
