### PR TITLE
Embed app and code

### DIFF
--- a/documentation/migrations/0021_example_example_app_display_type.py
+++ b/documentation/migrations/0021_example_example_app_display_type.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('documentation', '0020_map_blocks'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='example',
+            name='example_app_display_type',
+            field=models.CharField(default=(b'codeFromCodeField', b'Display app with code from code field above'), help_text=b'How the app and code fields for this example are rendered', max_length=255, choices=[(b'codeFromCodeField', b'Display app with code from code field above'), (b'embedAppWithCode', b'Embed app with code directly from code.org project')]),
+        ),
+    ]

--- a/documentation/migrations/0022_auto_20200512_0310.py
+++ b/documentation/migrations/0022_auto_20200512_0310.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('documentation', '0021_example_example_app_display_type'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='example',
+            old_name='example_app_display_type',
+            new_name='app_display_type',
+        ),
+    ]

--- a/documentation/migrations/0023_auto_20200514_0024.py
+++ b/documentation/migrations/0023_auto_20200514_0024.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('documentation', '0022_auto_20200512_0310'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='example',
+            name='app_display_type',
+            field=models.CharField(default=b'codeFromCodeField', help_text=b'How the app and code fields for this example are rendered', max_length=255, choices=[(b'codeFromCodeField', b'Display app with code from code field above'), (b'embedAppWithCode', b'Embed app with code directly from code.org project')]),
+        ),
+    ]

--- a/documentation/models.py
+++ b/documentation/models.py
@@ -294,11 +294,9 @@ class Example(Orderable, CloneableMixin):
 
     def _append_suffix_to_app(self, suffix):
          if self.app:
-            re_url = '\w*(localhost-studio.code.org:3000\/p\w*\/\w+\/\w+)'
-            #re_url = '\w*(studio.code.org\/p\w*\/\w+\/\w+)'
+            re_url = '\w*(studio.code.org\/p\w*\/\w+\/\w+)'
             if re.search(re_url, self.app):
-                #app_with_suffix = 'https://%s/%s' % (re.search(re_url, self.app).group(0), suffix)
-                app_with_suffix = 'http://%s/%s' % (re.search(re_url, self.app).group(0), suffix)
+                app_with_suffix = 'https://%s/%s' % (re.search(re_url, self.app).group(0), suffix)
                 return app_with_suffix
 
     def get_embed_app(self):

--- a/documentation/models.py
+++ b/documentation/models.py
@@ -284,21 +284,28 @@ class Example(Orderable, CloneableMixin):
     ]
 
     app_display_type = models.CharField(
-		    max_length=255,
+        max_length=255,
         choices=app_display_type_options,
-        default=app_display_type_options[0],
+        default=app_display_type_options[0][0],
         help_text='How the app and code fields for this example are rendered')
 
     def __unicode__(self):
         return self.name
 
+    def _append_suffix_to_app(self, suffix):
+         if self.app:
+            re_url = '\w*(localhost-studio.code.org:3000\/p\w*\/\w+\/\w+)'
+            #re_url = '\w*(studio.code.org\/p\w*\/\w+\/\w+)'
+            if re.search(re_url, self.app):
+                #app_with_suffix = 'https://%s/%s' % (re.search(re_url, self.app).group(0), suffix)
+                app_with_suffix = 'http://%s/%s' % (re.search(re_url, self.app).group(0), suffix)
+                return app_with_suffix
+
     def get_embed_app(self):
-        if self.app:
-            return self.app + '/embed'
+        return self._append_suffix_to_app('embed')
 
     def get_embed_app_and_code(self):
-        if self.app:
-            return self.app + '/embed_app_and_code'
+        return self._append_suffix_to_app('embed_app_and_code')
 
 
 """

--- a/documentation/models.py
+++ b/documentation/models.py
@@ -278,19 +278,27 @@ class Example(Orderable, CloneableMixin):
     app = models.URLField(blank=True, null=True, help_text='Sharing link for example app')
     image = models.ImageField(blank=True, null=True)
 
+    app_display_type_options = [
+        ('codeFromCodeField', 'Display app with code from code field above'),
+        ('embedAppWithCode', 'Embed app with code directly from code.org project')
+    ]
+
+    app_display_type = models.CharField(
+		    max_length=255,
+        choices=app_display_type_options,
+        default=app_display_type_options[0],
+        help_text='How the app and code fields for this example are rendered')
+
     def __unicode__(self):
         return self.name
 
     def get_embed_app(self):
         if self.app:
-            re_url = '\w*(studio.code.org\/p\w*\/\w+\/\w+)'
-            if re.search(re_url, self.app):
-                embed_code = 'https://%s/embed' % re.search(re_url, self.app).group(0)
-                return embed_code
-            else:
-                return
-        else:
-            return
+            return self.app + '/embed'
+
+    def get_embed_app_and_code(self):
+        if self.app:
+            return self.app + '/embed_app_and_code'
 
 
 """

--- a/documentation/templates/documentation/partials/block.html
+++ b/documentation/templates/documentation/partials/block.html
@@ -72,7 +72,7 @@
                 </div>
             {% elif example.app_display_type == 'embedAppWithCode' %}
                 <iframe class="embed-app-with-code-exemplar" src={{ example.get_embed_app_and_code }}></iframe>
-						{% endif %}
+            {% endif %}
         {% elif example.image %}
             <div class="row">
                 <div class="col-sm-8">

--- a/documentation/templates/documentation/partials/block.html
+++ b/documentation/templates/documentation/partials/block.html
@@ -57,18 +57,22 @@
     {% for example in code_block.examples.all %}
         {% editable example.name example.description example.code %}
         {% if example.app %}
-            <div class="row">
-                <div class="col-sm-8">
-                    <h3>{{ example.name }}</h3>
-                    <p>{{ example.description|richtext_filters|safe }}</p>
-<pre>
-{{ example.code }}
-</pre>
-                </div>
+            {% if example.app_display_type == 'codeFromCodeField' %}
+                <div class="row">
+                    <div class="col-sm-8">
+                        <h3>{{ example.name }}</h3>
+                        <p>{{ example.description|richtext_filters|safe }}</p>
+                        <pre>
+                            {{ example.code }}
+                        </pre>
+                    </div>
                     <div class="col-sm-4">
                         <iframe class="{{ code_block.parent_ide.slug }}-exemplar" src="{{ example.get_embed_app }}"></iframe>
                     </div>
-            </div>
+                </div>
+            {% elif example.app_display_type == 'embedAppWithCode' %}
+                <iframe class="embed-app-with-code-exemplar" src={{ example.get_embed_app_and_code }}></iframe>
+						{% endif %}
         {% elif example.image %}
             <div class="row">
                 <div class="col-sm-8">

--- a/static/cdo/css/applab-docs.css
+++ b/static/cdo/css/applab-docs.css
@@ -122,6 +122,12 @@
     display: block;
 }
 
+.spritelab-exemplar {
+    width: 100%;
+    height: 620px;
+    border: 0;
+}
+
 .gamelab-exemplar {
     width: 450px;
     height: 757px;

--- a/static/cdo/css/applab-docs.css
+++ b/static/cdo/css/applab-docs.css
@@ -122,9 +122,9 @@
     display: block;
 }
 
-.spritelab-exemplar {
+.embed-app-with-code-exemplar {
     width: 100%;
-    height: 620px;
+    height: 310px;
     border: 0;
 }
 


### PR DESCRIPTION
This PR is the curriculumbuilder side of changes that allow us to embed projects directly in curriculumbuilder documentation. These changes add a new field,  'App Display Type', which specifies weather an app link in a documentation example should resolve to the new view (app with code from the project) or the old view (code is specified in curriculumbuilder, app is rendered from project). 

New view on docs page:
- [jira](https://codedotorg.atlassian.net/browse/LP-790)
![Screenshot from 2020-05-14 00-08-40](https://user-images.githubusercontent.com/58449474/81906236-cc0a5780-957a-11ea-9a29-3f66931ce662.png)

New field in curriculum builder admin page:
![Screenshot from 2020-05-14 00-14-19](https://user-images.githubusercontent.com/58449474/81906257-d167a200-957a-11ea-93fc-2592f8b1e99c.png)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
