### PR TITLE
Explanatory text and links for CSF standards and cross-curricular opportunities

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -336,6 +336,9 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return self.i18n_ready
 
     @property
+    def is_csf(self):
+        return self.curriculum.slug.startswith('csf')
+
     def has_resource_pdf(self):
         return self.curriculum.slug not in ['csf-18', 'csf-1718', 'hoc']
 

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -248,8 +248,8 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return Unit.objects.filter(parent=self, login_required=False)
 
     @property
-    def is_csf(self):
-        return Unit.objects.filter(parent=self, login_required=False)[0].is_csf
+    def has_cross_curricular_info(self):
+        return Unit.objects.filter(parent=self, login_required=False)[0].has_cross_curricular_info
 
     @property
     def should_be_translated(self):
@@ -340,8 +340,8 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return self.i18n_ready
 
     @property
-    def is_csf(self):
-        return self.curriculum.slug.startswith('csf')
+    def has_cross_curricular_info(self):
+        return self.curriculum.slug == 'csf-20'
 
     def has_resource_pdf(self):
         return self.curriculum.slug not in ['csf-18', 'csf-1718', 'hoc']

--- a/curricula/models.py
+++ b/curricula/models.py
@@ -248,6 +248,10 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return Unit.objects.filter(parent=self, login_required=False)
 
     @property
+    def is_csf(self):
+        return Unit.objects.filter(parent=self, login_required=False)[0].is_csf
+
+    @property
     def should_be_translated(self):
         return any(unit.should_be_translated for unit in self.units)
 

--- a/standards/templates/standards/curriculum_nogrid.html
+++ b/standards/templates/standards/curriculum_nogrid.html
@@ -59,7 +59,20 @@
         {% endif %}
     {% endif %}
     </div>
-
+    <h2>How should I use this information?</h2>
+    <p>
+      <span style="font-weight:900;">CSTA Standards Alignment</span>: Code.org’s CS Fundamentals course is aligned with the Computer Science Teachers’ Association (CSTA) standards for K-5 students. You can hit these standards by following our lesson plans. You can also see what CSTA standards your class has worked on in the Standards view of the teacher dashboard
+    </p>
+    <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
+        <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download standards mapping as CSV' %}
+    </a>
+    <p>
+      <span style="font-weight:900;">Cross-Curricular Standards</span>: Computer science helps students with problem-solving, logical thinking, cause and effect, and computational thinking. CS Fundamentals also includes opportunities for teachers to reinforce concepts related to English language arts, mathematics, and science while students are learning computer science. You can help students practice these standards just by following our lesson plans or by making slight adaptations, as outlined in our Cross-curricular Standards Guidance below.
+    </p>
+    <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
+        <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download Cross-Curricular Standards Guidance as a PDF' %}
+    </a>
+    <h2>Standards Alignment</h2>
     <div class="together standards row">
     <button class="btn" id="expand-all"><span class="glyphicon glyphicon-resize-full" aria-hidden="true"></span> {% trans 'Expand All' %}</button>
     <button class="btn" id="collapse-all"><span class="glyphicon glyphicon-resize-small" aria-hidden="true"></span> {% trans 'Collapse All' %}</button>

--- a/standards/templates/standards/curriculum_nogrid.html
+++ b/standards/templates/standards/curriculum_nogrid.html
@@ -59,17 +59,17 @@
         {% endif %}
     {% endif %}
     </div>
-    {% if curriculum.is_csf%}
+    {% if curriculum.has_cross_curricular_info %}
       <div>
         <h2>How should I use this information?</h2>
         <p>
           <span style="font-weight:900;">CSTA Standards Alignment</span>: Code.org’s CS Fundamentals course is aligned with the Computer Science Teachers’ Association (CSTA) standards for K-5 students. You can hit these standards by following our lesson plans. You can also see what CSTA standards your class has worked on in the Standards view of the teacher dashboard. <a href="https://support.code.org/hc/en-us/articles/360041726272-Can-I-see-my-class-s-progress-on-CSTA-Standards-Is-there-an-easy-progress-report-I-can-send-out-for-my-class-">Learn more.</a>
         </p>
-        <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
+        <a class="btn" role="button" style="font-size: 16px; padding-left: 0px;" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
             <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download standards mapping as CSV' %}
         </a>
         <p>
-          <span style="font-weight:900;">Cross-Curricular Standards</span>: Computer science helps students with problem-solving, logical thinking, cause and effect, and computational thinking. CS Fundamentals also includes opportunities for teachers to reinforce concepts related to English language arts, mathematics, and science while students are learning computer science. You can help students practice these standards just by following our lesson plans or by making slight adaptations, as outlined in our Cross-curricular Standards Guidance below.
+          <span style="font-weight:900;">Cross-Curricular Standards</span>: Computer science helps students with problem-solving, logical thinking, cause and effect, and computational thinking. CS Fundamentals also includes opportunities for teachers to reinforce concepts related to English language arts, mathematics, and science while students are learning computer science. You can help students practice these standards just by following our lesson plans or by making slight adaptations, as outlined in our Cross-Curricular Standards Guidance below.
         </p>
         <a href="https://docs.google.com/document/d/e/2PACX-1vRxKtK0HZ4jlqDG0kf5J8l0p_wTGZRQCwBY8HupNVl2EiPC7qs-57Ct0zMyLxuGEuWJX3lF9QbsDUNY/pub">
           Cross-Curricular Standards Guidance
@@ -77,12 +77,12 @@
         <h2>Standards Alignment</h2>
       </div>
     {% endif %}
-    <div class="together standards row">
+    <div class="together standards row" style="margin-left: 0px;">
     <button class="btn" id="expand-all"><span class="glyphicon glyphicon-resize-full" aria-hidden="true"></span> {% trans 'Expand All' %}</button>
     <button class="btn" id="collapse-all"><span class="glyphicon glyphicon-resize-small" aria-hidden="true"></span> {% trans 'Collapse All' %}</button>
     {% if unit %}{# If unit is passed, just grab that unit #}
         <br/>
-        {% if not curriculum.is_csf%}
+        {% if not curriculum.has_cross_curricular_info %}
           <a class="btn" role="button" href="{% url 'curriculum:by_unit_csv' curriculum.slug unit.slug %}">
               <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download as CSV' %}
           </a>
@@ -110,7 +110,7 @@
         </div>
     {% else %}
         <br/>
-        {% if not curriculum.is_csf%}
+        {% if not curriculum.has_cross_curricular_info %}
           <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
               <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download as CSV' %}
           </a>

--- a/standards/templates/standards/curriculum_nogrid.html
+++ b/standards/templates/standards/curriculum_nogrid.html
@@ -59,7 +59,7 @@
         {% endif %}
     {% endif %}
     </div>
-    {% if unit and unit.is_csf%}
+    {% if curriculum.is_csf%}
       <div>
         <h2>How should I use this information?</h2>
         <p>
@@ -71,8 +71,8 @@
         <p>
           <span style="font-weight:900;">Cross-Curricular Standards</span>: Computer science helps students with problem-solving, logical thinking, cause and effect, and computational thinking. CS Fundamentals also includes opportunities for teachers to reinforce concepts related to English language arts, mathematics, and science while students are learning computer science. You can help students practice these standards just by following our lesson plans or by making slight adaptations, as outlined in our Cross-curricular Standards Guidance below.
         </p>
-        <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
-            <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download Cross-Curricular Standards Guidance as a PDF' %}
+        <a href="https://docs.google.com/document/d/e/2PACX-1vRxKtK0HZ4jlqDG0kf5J8l0p_wTGZRQCwBY8HupNVl2EiPC7qs-57Ct0zMyLxuGEuWJX3lF9QbsDUNY/pub">
+          Cross-Curricular Standards Guidance
         </a>
         <h2>Standards Alignment</h2>
       </div>
@@ -82,7 +82,7 @@
     <button class="btn" id="collapse-all"><span class="glyphicon glyphicon-resize-small" aria-hidden="true"></span> {% trans 'Collapse All' %}</button>
     {% if unit %}{# If unit is passed, just grab that unit #}
         <br/>
-        {% if not unit.is_csf%}
+        {% if not curriculum.is_csf%}
           <a class="btn" role="button" href="{% url 'curriculum:by_unit_csv' curriculum.slug unit.slug %}">
               <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download as CSV' %}
           </a>
@@ -110,9 +110,11 @@
         </div>
     {% else %}
         <br/>
-        <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
-            <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download as CSV' %}
-        </a>
+        {% if not curriculum.is_csf%}
+          <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
+              <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download as CSV' %}
+          </a>
+        {% endif %}
         {% for unit in curriculum.units %}
         <div class="together">
             <h2><a href="{{ unit.get_absolute_url }}">Unit {{ unit.number }}: {{ unit.title }}</a></h2>

--- a/standards/templates/standards/curriculum_nogrid.html
+++ b/standards/templates/standards/curriculum_nogrid.html
@@ -59,28 +59,34 @@
         {% endif %}
     {% endif %}
     </div>
-    <h2>How should I use this information?</h2>
-    <p>
-      <span style="font-weight:900;">CSTA Standards Alignment</span>: Code.org’s CS Fundamentals course is aligned with the Computer Science Teachers’ Association (CSTA) standards for K-5 students. You can hit these standards by following our lesson plans. You can also see what CSTA standards your class has worked on in the Standards view of the teacher dashboard
-    </p>
-    <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
-        <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download standards mapping as CSV' %}
-    </a>
-    <p>
-      <span style="font-weight:900;">Cross-Curricular Standards</span>: Computer science helps students with problem-solving, logical thinking, cause and effect, and computational thinking. CS Fundamentals also includes opportunities for teachers to reinforce concepts related to English language arts, mathematics, and science while students are learning computer science. You can help students practice these standards just by following our lesson plans or by making slight adaptations, as outlined in our Cross-curricular Standards Guidance below.
-    </p>
-    <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
-        <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download Cross-Curricular Standards Guidance as a PDF' %}
-    </a>
-    <h2>Standards Alignment</h2>
+    {% if unit and unit.is_csf%}
+      <div>
+        <h2>How should I use this information?</h2>
+        <p>
+          <span style="font-weight:900;">CSTA Standards Alignment</span>: Code.org’s CS Fundamentals course is aligned with the Computer Science Teachers’ Association (CSTA) standards for K-5 students. You can hit these standards by following our lesson plans. You can also see what CSTA standards your class has worked on in the Standards view of the teacher dashboard. <a href="https://support.code.org/hc/en-us/articles/360041726272-Can-I-see-my-class-s-progress-on-CSTA-Standards-Is-there-an-easy-progress-report-I-can-send-out-for-my-class-">Learn more.</a>
+        </p>
+        <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
+            <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download standards mapping as CSV' %}
+        </a>
+        <p>
+          <span style="font-weight:900;">Cross-Curricular Standards</span>: Computer science helps students with problem-solving, logical thinking, cause and effect, and computational thinking. CS Fundamentals also includes opportunities for teachers to reinforce concepts related to English language arts, mathematics, and science while students are learning computer science. You can help students practice these standards just by following our lesson plans or by making slight adaptations, as outlined in our Cross-curricular Standards Guidance below.
+        </p>
+        <a class="btn" role="button" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
+            <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download Cross-Curricular Standards Guidance as a PDF' %}
+        </a>
+        <h2>Standards Alignment</h2>
+      </div>
+    {% endif %}
     <div class="together standards row">
     <button class="btn" id="expand-all"><span class="glyphicon glyphicon-resize-full" aria-hidden="true"></span> {% trans 'Expand All' %}</button>
     <button class="btn" id="collapse-all"><span class="glyphicon glyphicon-resize-small" aria-hidden="true"></span> {% trans 'Collapse All' %}</button>
     {% if unit %}{# If unit is passed, just grab that unit #}
         <br/>
-        <a class="btn" role="button" href="{% url 'curriculum:by_unit_csv' curriculum.slug unit.slug %}">
-            <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download as CSV' %}
-        </a>
+        {% if not unit.is_csf%}
+          <a class="btn" role="button" href="{% url 'curriculum:by_unit_csv' curriculum.slug unit.slug %}">
+              <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download as CSV' %}
+          </a>
+        {% endif %}
         <div class="together">
             <h2><a href="{{ unit.get_absolute_url }}">{{ unit.long_name }}</a></h2>
 


### PR DESCRIPTION
[LP-1250](https://codedotorg.atlassian.net/browse/LP-1250) partial 

CSF overview standards pages will now how explanatory text introducing standards and cross-curricular opportunities: 
<img width="1119" alt="csf-overview" src="https://user-images.githubusercontent.com/12300669/82103977-f3236f00-96c9-11ea-9aaa-e26cc08eb696.png">

Same for specific CSF courses: 
<img width="1099" alt="specific_course" src="https://user-images.githubusercontent.com/12300669/82103988-033b4e80-96ca-11ea-844a-5140f2b8be3d.png">

Non-CSF course standards pages on curriculum.code.org will remain unchanged: 
<img width="1109" alt="Screen Shot 2020-05-15 at 12 53 23 PM" src="https://user-images.githubusercontent.com/12300669/82104013-15b58800-96ca-11ea-950f-a2e5086d0658.png">
<img width="1114" alt="Screen Shot 2020-05-15 at 12 53 41 PM" src="https://user-images.githubusercontent.com/12300669/82104015-16e6b500-96ca-11ea-9eba-395f75d41230.png">

