### PR TITLE
disable mdlightbox plugin

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -483,7 +483,7 @@ PAGEDOWN_MARKDOWN_EXTENSIONS = (
     'curriculumBuilder.doclinks',
     'extra', 'codehilite', 'toc', 'curriculumBuilder.newtab', 'curriculumBuilder.absolute_images',
     # 'curriculumBuilder.resourcelinks', 'curriculumBuilder.highlightblocks', 'smarty',
-    'curriculumBuilder.resourcelinks', 'curriculumBuilder.mdlightbox',
+    'curriculumBuilder.resourcelinks',
     'curriculumBuilder.vocablinks', 'curriculumBuilder.tips', 'curriculumBuilder.tiplinks',
     'curriculumBuilder.iconfonts', 'curriculumBuilder.codestudio', 'curriculumBuilder.divclass')
 RICHTEXT_FILTER_LEVEL = 3


### PR DESCRIPTION
disable the mdlightbox plugin, which automatically wraps all images on curriculumbuilder in a [lightbox](https://en.wikipedia.org/wiki/Lightbox_(JavaScript)). there are two reasons for this:

1. As part of moving block and concept docs from Curriculum Builder to Level Builder, we need to eliminate html syntax from markdown. to accomplish that, we'd like to be able to use markdown to create images which are also links. The current lightbox plugin prevents that, because it overwrites the link target with a link to 

2. The current behavior is broken anyway (see screenshots). clicking the image navigates to the image, instead of opening a lightbox.

### before

<img width="1546" alt="Screen Shot 2020-05-30 at 10 34 48 AM" src="https://user-images.githubusercontent.com/8001765/83335372-40bee080-a261-11ea-8117-dfee8d61c266.png">


^ you can see at bottom left (and in the html) that the image is a simple link to itself
 
### after

<img width="1543" alt="Screen Shot 2020-05-30 at 10 22 20 AM" src="https://user-images.githubusercontent.com/8001765/83335302-b4acb900-a260-11ea-8fbb-5667ce590c80.png">

