### PR TITLE
Increase height of gamelab-exemplar

### DIFF
--- a/static/cdo/css/applab-docs.css
+++ b/static/cdo/css/applab-docs.css
@@ -129,7 +129,7 @@
 
 .gamelab-exemplar {
     width: 450px;
-    height: 757px;
+    height: 781px;
     border: 0;
 
     -ms-transform: scale(0.5);


### PR DESCRIPTION
Previously, the iframe's height was too low. Examples would get the app border
cut off, causing a worse user experience (though it was still functional). This
change allows the app border to render

# Description
Before:
![Screenshot from 2020-06-25 02-50-45](https://user-images.githubusercontent.com/58449474/85698816-dba7b080-b68f-11ea-9357-281c2cce810a.png)

After:
![Screenshot from 2020-06-25 02-52-19](https://user-images.githubusercontent.com/58449474/85698855-e4988200-b68f-11ea-813c-77dbb42b8a0b.png)


<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
