### PR TITLE
Always Link Unit PDFs to curriculum.code.org

### DIFF
--- a/curricula/templates/curricula/partials/unit_pills.html
+++ b/curricula/templates/curricula/partials/unit_pills.html
@@ -7,10 +7,10 @@
       {% if unit.vocab_count > 0 %}<a href="{{ unit.get_vocab_url }}" class="btn" role="button">{% trans 'Vocab' context 'Vocabulary' %}</a>{% endif %}
       {% if unit.block_count > 0 %}<a href="{{ unit.get_blocks_url }}" class="btn" role="button">{% trans 'Code Documentation' %}</a>{% endif %}
       <a href="{{ unit.get_resources_url }}" class="btn" role="button">{% trans 'Other Resources' %}</a>
-      <a href="{{ unit.get_pdf_url }}" class="btn" role="button">{% trans 'Lessons PDF' %}</a>
+      <a href="https://curriculum.code.org{{ unit.get_pdf_url }}" class="btn" role="button">{% trans 'Lessons PDF' %}</a>
         {# Removing handouts PDF link from CSF until we can fix it #}
         {% if unit.has_resource_pdf %}
-        <a href="{{ unit.get_resources_pdf_url }}" class="btn" role="button">{% trans 'Handouts PDF' %}</a>
+        <a href="https://curriculum.code.org{{ unit.get_resources_pdf_url }}" class="btn" role="button">{% trans 'Handouts PDF' %}</a>
         {% endif %}
         {% if changelog.count > 0 %}
 


### PR DESCRIPTION
This is to ensure that Unit PDFs on codecurricula.com always show if they have
been published. Previously, the django app would re-generate Unit PDFs every
time they were requested, which could cause timeout errors that confuse site
visitors.

This change was made to address bug reports we got where folks requesting PDFs on codecurricula.com via these links would sometimes get error pages. They will now never get error pages if the PDFs for these pages have already been published - pdf publishing functionality has remained unchanged.

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1495)

## Testing story
Tested by verifying links work as expected manually.

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
