### PR TITLE
Allow use of unicode in resourcelinks

### DIFF
--- a/curriculumBuilder/resourcelinks.py
+++ b/curriculumBuilder/resourcelinks.py
@@ -24,14 +24,14 @@ class AttrTagPattern(Pattern):
     try:
       resource = Resource.objects.get(slug=el.text)
       el.set('href', resource.fallback_url())
-      el.text = str(resource)
+      el.text = unicode(resource)
 
     except Resource.DoesNotExist:
       try:
         resource = Resource.objects.filter(name=el.text).first()
         if resource:
           el.set('href', resource.fallback_url())
-          el.text = str(resource)
+          el.text = unicode(resource)
         else:
           el.text = "<span class='text-danger'>resource %s not found</span>" % el.text
 

--- a/curriculumBuilder/tests/test_resourcelinks.py
+++ b/curriculumBuilder/tests/test_resourcelinks.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+from django.contrib.auth.models import User
+from mezzanine.core.templatetags.mezzanine_tags import richtext_filters
+from lessons.models import Resource
+
+
+class ResourceLinksTestCase(TestCase):
+    """
+    Test our custom "resourcelinks" markdown plugin
+    """
+    def setUp(self):
+        # For some reason, Resources need an associated User. So, create one.
+        self.test_user, _created = User.objects.get_or_create(
+            username="username",
+            password="password"
+        )
+
+    def tearDown(self):
+        self.test_user.delete()
+
+    def test_rendering_basic_resource_link(self):
+        Resource(name="name", type="type", slug="slug", url="url", user=self.test_user).save()
+        markdown = "[r slug]"
+        expected = '<p><a class="resource" href="url" target="_blank">name - type</a></p>'
+        self.assertEqual(expected, richtext_filters(markdown))
+
+    def test_rendering_resource_link_with_unicode(self):
+        Resource(name=u"náme", type=u"typê", slug=u"slüg", url="url", user=self.test_user).save()
+        markdown = u"[r slüg]"
+        expected = u'<p><a class="resource" href="url" target="_blank">náme - typê</a></p>'
+        self.assertEqual(expected, richtext_filters(markdown))


### PR DESCRIPTION
Specifically to support translations which use unicode; currently, attempts to render translated resourcelinks that include accented characters fail with a UnicodeDecodeError.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/244100/87364850-8beb3500-c529-11ea-9468-4bdae7cbb788.png) | ![image](https://user-images.githubusercontent.com/244100/87364867-93124300-c529-11ea-9a43-6c5906e00f32.png)


## Links

- [jira](https://codedotorg.atlassian.net/browse/FND-1210)

## Testing story

Also add a basic unit test.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
