### PR TITLE
add code studio url override to lesson model

### DIFF
--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -328,7 +328,7 @@ class LessonAdmin(PageAdmin, AjaxSelectAdmin, CompareVersionAdmin, FilterableAdm
         fieldsets = (
             (None, {
                 'fields': ['title', 'short_title', status_fields, 'image',
-                           'overview', 'keywords', ('description', 'gen_description')],
+                           'overview', 'keywords', ('description', 'gen_description'), 'code_studio_url'],
             }),
             ('Assessment', {
                 'fields': ['assessment'],

--- a/lessons/migrations/0048_lesson_code_studio_url.py
+++ b/lessons/migrations/0048_lesson_code_studio_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lessons', '0047_auto_20200402_1718'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='lesson',
+            name='code_studio_url',
+            field=models.CharField(help_text=b'Link to the first puzzle of this lesson on code studio. Leave blank to auto-generate.', max_length=255, null=True, verbose_name=b'Custom Code Studio URL', blank=True),
+        ),
+    ]

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -361,6 +361,9 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Filterable):
     pacing_weight = models.DecimalField('Pacing Weight', help_text='Higher numbers take up more space pacing calendar',
                                         default=1, max_digits=4, decimal_places=1, blank=True, null=True)
     unplugged = models.BooleanField(default=False)
+    code_studio_url = models.CharField('Custom Code Studio URL',
+                                help_text='Link to the first puzzle of this lesson on code studio. Leave blank to auto-generate.',
+                                max_length=255, blank=True, null=True)
     resources = SortedManyToManyField(Resource, blank=True, related_name='lessons')
     prep = RichTextField('Preparation', help_text='ToDos for the teacher to prep this lesson', blank=True, null=True)
     assessment = RichTextField('Assessment Opportunities',

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -714,7 +714,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Filterable):
 
     @property
     def code_studio_link(self):
-        return "https://studio.code.org/s/%s/stage/%d/puzzle/1/" % (
+        return self.code_studio_url or "https://studio.code.org/s/%s/stage/%d/puzzle/1/" % (
             self.unit.unit_name, self.number)
 
     @property


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-240 . See https://github.com/code-dot-org/curriculumbuilder/pull/297 for migration PR.

### Testing 

Manually verified the following:

How the field appears on the lesson admin page:
![Screen Shot 2020-07-20 at 2 50 38 PM](https://user-images.githubusercontent.com/8001765/87990395-c8261480-ca98-11ea-811c-261f2f6346cf.png)

new link viewable on hover over the View on Code Studio link:

![Screen Shot 2020-07-20 at 2 50 54 PM](https://user-images.githubusercontent.com/8001765/87990464-e5f37980-ca98-11ea-8b1d-18c04bbca61d.png)

Also, no change to behavior on lessons with blank code_studio_url field.

Since we don't expect this code to live long, I haven't added any unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
