### PR TITLE
Hide blocks and vocab tabs if there are no blocks or vocab

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -240,6 +240,20 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
         return columns, rows
 
     @property
+    def block_count(self):
+        num_blocks = 0
+        for unit in self.units:
+            num_blocks += unit.block_count
+        return num_blocks
+
+    @property
+    def vocab_count(self):
+        num_vocab = 0
+        for unit in self.units:
+            num_vocab += unit.vocab_count
+        return num_vocab
+
+    @property
     def maps(self):
         return Map.objects.filter(parent=self)
 

--- a/curricula/templates/curricula/partials/curriculum_pills.html
+++ b/curricula/templates/curricula/partials/curriculum_pills.html
@@ -2,8 +2,8 @@
 <div class="resource-nav btn-toolbar" role="toolbar" aria-label="Unit Resources">
     <div class="btn-group btn-group-xs" role="group" aria-label="PDF Buttons">
         <a href="{{ curriculum.get_absolute_url }}standards/" class="btn" role="button">{% trans "Standards" %}</a>
-        <a href="{{ curriculum.get_absolute_url }}vocab/" class="btn" role="button">{% trans "Vocab" %}</a>
-        <a href="{{ curriculum.get_absolute_url }}code/" class="btn" role="button">{% trans "Code Documentation" %}</a>
+        {% if curriculum.vocab_count > 0 %}<a href="{{ curriculum.get_absolute_url }}vocab/" class="btn" role="button">{% trans "Vocab" %}</a>{% endif %}
+        {% if curriculum.block_count > 0 %}<a href="{{ curriculum.get_absolute_url }}code/" class="btn" role="button">{% trans "Code Documentation" %}</a>{% endif %}
         <a href="{{ curriculum.get_absolute_url }}resources/" class="btn" role="button">{% trans "Other Resources" %}</a>
         {% if changelog.count > 0 %}
 


### PR DESCRIPTION
# Overview

The new CSP course does not have linked blocks or vocab in lesson plans. The unit overview page already hides the tabs for the all blocks and all vocab page if there are no blocks or no vocab. This hides the tabs on the curriculum overview page if there are no blocks or no vocab.

# Testing

I checked that csp-20 now hides the correct tabs and that csd-20 does not hide those tabs because it does have vocab and blocks.

<img width="1022" alt="Screen Shot 2020-07-22 at 10 00 41 AM" src="https://user-images.githubusercontent.com/208083/88186003-a3e64700-cc02-11ea-9a63-62000606693a.png">
<img width="1035" alt="Screen Shot 2020-07-22 at 10 00 35 AM" src="https://user-images.githubusercontent.com/208083/88186007-a5177400-cc02-11ea-9a06-21af4bba7490.png">
