### PR TITLE
Parallelize "publish" operations in I18n sync

### DIFF
--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -23,10 +23,10 @@ def publish(obj):
 
     for language_code in Command.language_codes:
         translation.activate(language_code)
+
         if hasattr(obj, 'publish'):
             list(obj.publish(silent=True))
-        # Temporary hack to turn off PDF generation while still directing users to the
-        # translated pdfs if they exist
+
         if language_code in settings.LANGUAGE_GENERATE_PDF and hasattr(obj, 'publish_pdfs'):
             try:
                 pdf_generation_start_time = time.time()


### PR DESCRIPTION
# Description

Specifically, parallelize the act of iterating through each model object. Testing on my local machine confirms that this speeds up the publish step proportional to the number of processor cores used. It looks like heroku dynos have between 2 and 4 cores, so we should expect a comparable speedup.

Once we've deployed this and looked into the results, I'd like to also explore the effects of allocating more resources to the dyno that runs the sync.

We could also look into parallelizing this at the language level rather than at the object level, but local testing doesn't indicate that that results in any significant improvement over this approach.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-625)

## Testing story

Manually tested.

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
