### PR TITLE
Add tests for Tips renderer

### DIFF
--- a/curriculumBuilder/tests/test_tips.py
+++ b/curriculumBuilder/tests/test_tips.py
@@ -17,12 +17,12 @@ class TipsTestCase(SimpleTestCase):
         )
         expected = (
             '<div class="admonition content">\n'
-            '<p class="admonition-title" id="content_content-0"><i class="fa fa-mortar-board"></i>Content Corner</p>\n'
-            '<div></div>\n'
-            '<div>\n'
-            '<h3 id="teaching-this-course-as-a-class">Teaching this course as a class?</h3>\n'
-            '<p>Our grade-aligned CS Fundamentals courses use unplugged lessons to build community and introduce tricky computer science concepts, including <strong>events</strong>. Check out the lesson <a href="https://curriculum.code.org/csf-19/coursea/11/" target="_blank">The Big Event Jr.</a> from <a href="https://curriculum.code.org/csf-19/coursea/" target="_blank">Course A</a>!</p>\n'
-            '</div>\n'
+              '<p class="admonition-title" id="content_content-0"><i class="fa fa-mortar-board"></i>Content Corner</p>\n'
+              '<div></div>\n'
+              '<div>\n'
+                '<h3 id="teaching-this-course-as-a-class">Teaching this course as a class?</h3>\n'
+                '<p>Our grade-aligned CS Fundamentals courses use unplugged lessons to build community and introduce tricky computer science concepts, including <strong>events</strong>. Check out the lesson <a href="https://curriculum.code.org/csf-19/coursea/11/" target="_blank">The Big Event Jr.</a> from <a href="https://curriculum.code.org/csf-19/coursea/" target="_blank">Course A</a>!</p>\n'
+              '</div>\n'
             '</div>'
         )
         self.assertEqual(expected, richtext_filters(markdown))
@@ -39,18 +39,18 @@ class TipsTestCase(SimpleTestCase):
         )
         expected = (
             '<div class="admonition discussion">\n'
-            '<p class="admonition-title" id="discussion_discussion-0"><i class="fa fa-comments"></i>Discussion Goal</p>\n'
-            '<div></div>\n'
-            '<div>\n'
-            '<p><strong>Goal:</strong> Aim to hear a few different students share reasons that instructions are "bad". The point here is just to get students thinking and there\'s no specific answer you\'re driving towards. Some possible ideas, however, might include:</p>\n'
-            '</div>\n'
-            '<div>\n'
-            '<ul>\n'
-            '<li>Instructions are not clear on what to do</li>\n'
-            '<li>Instructions use confusing words</li>\n'
-            '<li>Instructions don\'t actually accomplish what they\'re supposed to</li>\n'
-            '</ul>\n'
-            '</div>\n'
+              '<p class="admonition-title" id="discussion_discussion-0"><i class="fa fa-comments"></i>Discussion Goal</p>\n'
+              '<div></div>\n'
+              '<div>\n'
+                '<p><strong>Goal:</strong> Aim to hear a few different students share reasons that instructions are "bad". The point here is just to get students thinking and there\'s no specific answer you\'re driving towards. Some possible ideas, however, might include:</p>\n'
+              '</div>\n'
+              '<div>\n'
+                '<ul>\n'
+                  '<li>Instructions are not clear on what to do</li>\n'
+                  '<li>Instructions use confusing words</li>\n'
+                  '<li>Instructions don\'t actually accomplish what they\'re supposed to</li>\n'
+                '</ul>\n'
+              '</div>\n'
             '</div>'
         )
         self.assertEqual(expected, richtext_filters(markdown))
@@ -70,10 +70,49 @@ class TipsTestCase(SimpleTestCase):
         )
         expected = (
             '<div class="admonition guide">\n'
-            '<div></div>\n'
-            '<div>\n'
-            '<p>inner content</p>\n'
-            '</div>\n'
+              '<div></div>\n'
+              '<div>\n'
+                '<p>inner content</p>\n'
+              '</div>\n'
             '</div>'
+        )
+        self.assertEqual(expected, richtext_filters(markdown))
+
+    def test_rendering_two_paragraphs(self):
+        # Rendering a title, a blank line, and 2 paragraphs with a blank line in between.
+        # Each paragraph will be wrapped in its own div.
+        markdown = (
+            "!!!guide <content-0>\n"
+            "\n"
+            "    This is the first paragraph\n"
+            "    \n"
+            "    Second paragraph\n"
+        )
+        expected = (
+            '<div class="admonition guide">\n'
+              '<div></div>\n'
+              '<div>\n'
+                '<p>This is the first paragraph</p>\n'
+              '</div>\n'
+              '<div>\n'
+                '<p>Second paragraph</p>\n'
+              '</div>\n'
+            '</div>'
+        )
+        self.assertEqual(expected, richtext_filters(markdown))
+
+    def test_rendering_no_blank_line(self):
+        # No blank line between a title and a paragraph.
+        # There won't be any empty div in the output.
+        markdown = (
+            "!!!guide <content-0>\n"
+            "    This is the only paragraph\n"
+        )
+        expected = (
+          '<div class="admonition guide">\n'
+            '<div>\n'
+              '<p>This is the only paragraph</p>\n'
+            '</div>\n'
+          '</div>'
         )
         self.assertEqual(expected, richtext_filters(markdown))

--- a/curriculumBuilder/tests/test_tips.py
+++ b/curriculumBuilder/tests/test_tips.py
@@ -17,12 +17,12 @@ class TipsTestCase(SimpleTestCase):
         )
         expected = (
             '<div class="admonition content">\n'
-              '<p class="admonition-title" id="content_content-0"><i class="fa fa-mortar-board"></i>Content Corner</p>\n'
-              '<div></div>\n'
-              '<div>\n'
-                '<h3 id="teaching-this-course-as-a-class">Teaching this course as a class?</h3>\n'
-                '<p>Our grade-aligned CS Fundamentals courses use unplugged lessons to build community and introduce tricky computer science concepts, including <strong>events</strong>. Check out the lesson <a href="https://curriculum.code.org/csf-19/coursea/11/" target="_blank">The Big Event Jr.</a> from <a href="https://curriculum.code.org/csf-19/coursea/" target="_blank">Course A</a>!</p>\n'
-              '</div>\n'
+                '<p class="admonition-title" id="content_content-0"><i class="fa fa-mortar-board"></i>Content Corner</p>\n'
+                '<div></div>\n'
+                '<div>\n'
+                    '<h3 id="teaching-this-course-as-a-class">Teaching this course as a class?</h3>\n'
+                    '<p>Our grade-aligned CS Fundamentals courses use unplugged lessons to build community and introduce tricky computer science concepts, including <strong>events</strong>. Check out the lesson <a href="https://curriculum.code.org/csf-19/coursea/11/" target="_blank">The Big Event Jr.</a> from <a href="https://curriculum.code.org/csf-19/coursea/" target="_blank">Course A</a>!</p>\n'
+                '</div>\n'
             '</div>'
         )
         self.assertEqual(expected, richtext_filters(markdown))
@@ -39,18 +39,18 @@ class TipsTestCase(SimpleTestCase):
         )
         expected = (
             '<div class="admonition discussion">\n'
-              '<p class="admonition-title" id="discussion_discussion-0"><i class="fa fa-comments"></i>Discussion Goal</p>\n'
-              '<div></div>\n'
-              '<div>\n'
-                '<p><strong>Goal:</strong> Aim to hear a few different students share reasons that instructions are "bad". The point here is just to get students thinking and there\'s no specific answer you\'re driving towards. Some possible ideas, however, might include:</p>\n'
-              '</div>\n'
-              '<div>\n'
-                '<ul>\n'
-                  '<li>Instructions are not clear on what to do</li>\n'
-                  '<li>Instructions use confusing words</li>\n'
-                  '<li>Instructions don\'t actually accomplish what they\'re supposed to</li>\n'
-                '</ul>\n'
-              '</div>\n'
+                '<p class="admonition-title" id="discussion_discussion-0"><i class="fa fa-comments"></i>Discussion Goal</p>\n'
+                '<div></div>\n'
+                '<div>\n'
+                    '<p><strong>Goal:</strong> Aim to hear a few different students share reasons that instructions are "bad". The point here is just to get students thinking and there\'s no specific answer you\'re driving towards. Some possible ideas, however, might include:</p>\n'
+                '</div>\n'
+                '<div>\n'
+                    '<ul>\n'
+                        '<li>Instructions are not clear on what to do</li>\n'
+                        '<li>Instructions use confusing words</li>\n'
+                        '<li>Instructions don\'t actually accomplish what they\'re supposed to</li>\n'
+                    '</ul>\n'
+                '</div>\n'
             '</div>'
         )
         self.assertEqual(expected, richtext_filters(markdown))
@@ -90,13 +90,13 @@ class TipsTestCase(SimpleTestCase):
         )
         expected = (
             '<div class="admonition guide">\n'
-              '<div></div>\n'
-              '<div>\n'
-                '<p>This is the first paragraph</p>\n'
-              '</div>\n'
-              '<div>\n'
-                '<p>Second paragraph</p>\n'
-              '</div>\n'
+                '<div></div>\n'
+                '<div>\n'
+                    '<p>This is the first paragraph</p>\n'
+                '</div>\n'
+                '<div>\n'
+                    '<p>Second paragraph</p>\n'
+                '</div>\n'
             '</div>'
         )
         self.assertEqual(expected, richtext_filters(markdown))
@@ -110,9 +110,9 @@ class TipsTestCase(SimpleTestCase):
         )
         expected = (
           '<div class="admonition guide">\n'
-            '<div>\n'
-              '<p>This is the only paragraph</p>\n'
-            '</div>\n'
+              '<div>\n'
+                  '<p>This is the only paragraph</p>\n'
+              '</div>\n'
           '</div>'
         )
         self.assertEqual(expected, richtext_filters(markdown))

--- a/curriculumBuilder/tests/test_tips.py
+++ b/curriculumBuilder/tests/test_tips.py
@@ -78,41 +78,75 @@ class TipsTestCase(SimpleTestCase):
         )
         self.assertEqual(expected, richtext_filters(markdown))
 
-    def test_rendering_two_paragraphs(self):
-        # Rendering a title, a blank line, and 2 paragraphs with a blank line in between.
-        # Each paragraph will be wrapped in its own div.
-        markdown = (
+    def test_rendering_div_wrapping(self):
+        # If there a new line between 2 elements, they will be wrapped in separate divs.
+        markdown_with_newline = (
             "!!!guide <content-0>\n"
             "\n"
-            "    This is the first paragraph\n"
+            "    # A header\n"
             "    \n"
-            "    Second paragraph\n"
+            "    A paragraph\n"
         )
-        expected = (
+        expected_with_newline = (
             '<div class="admonition guide">\n'
                 '<div></div>\n'
                 '<div>\n'
-                    '<p>This is the first paragraph</p>\n'
+                    '<h1 id="a-header">A header</h1>\n'
                 '</div>\n'
                 '<div>\n'
-                    '<p>Second paragraph</p>\n'
+                    '<p>A paragraph</p>\n'
                 '</div>\n'
             '</div>'
         )
-        self.assertEqual(expected, richtext_filters(markdown))
+        self.assertEqual(expected_with_newline, richtext_filters(markdown_with_newline))
 
-    def test_rendering_no_blank_line(self):
-        # No blank line between a title and a paragraph.
-        # There won't be any empty div in the output.
-        markdown = (
+        # Otherwise, if there is no newline between 2 elements, they will be wrapped in a same div.
+        markdown_without_newline = (
+            "!!!guide <content-0>\n"
+            "\n"
+            "    # A header\n"
+            "    A paragraph\n"
+        )
+        expected_without_newline = (
+            '<div class="admonition guide">\n'
+                '<div></div>\n'
+                '<div>\n'
+                    '<h1 id="a-header">A header</h1>\n'
+                    '<p>A paragraph</p>\n'
+                '</div>\n'
+            '</div>'
+        )
+        self.assertEqual(expected_without_newline, richtext_filters(markdown_without_newline))
+
+
+    def test_rendering_without_newline(self):
+        # If there is no newline between a title and a paragraph,
+        # there won't be any empty div in the output.
+        markdown_without_newline = (
             "!!!guide <content-0>\n"
             "    This is the only paragraph\n"
         )
-        expected = (
+        expected_without_empty_div = (
           '<div class="admonition guide">\n'
               '<div>\n'
                   '<p>This is the only paragraph</p>\n'
               '</div>\n'
           '</div>'
         )
-        self.assertEqual(expected, richtext_filters(markdown))
+        self.assertEqual(expected_without_empty_div, richtext_filters(markdown_without_newline))
+
+        # Otherwise, there will be an empty div in the output.
+        markdown_with_newline = (
+            "!!!guide <content-0>\n"
+            "\n"
+            "    This is the only paragraph\n"
+        )
+        expected_with_empty_div = (
+          '<div class="admonition guide">\n'
+              '<div></div>\n'
+              '<div>\n'
+                  '<p>This is the only paragraph</p>\n'
+              '</div>\n'
+          '</div>'
+        )
+        self.assertEqual(expected_with_empty_div, richtext_filters(markdown_with_newline))


### PR DESCRIPTION
[FND-1219](https://codedotorg.atlassian.net/browse/FND-1219): The python-markdown renderer has some strange behaviors, and we want to document two of them using unit-tests.
1. If there is a blank line between two paragraphs, they will be wrapped in separate divs.
2. If there is a blank line between a admonition title and a paragraph, it will render an empty div.

## Links
- [python-markdown](https://python-markdown.github.io/)
- [Admonition extension for python-markdown](https://python-markdown.github.io/extensions/admonition/)
- [babelmark](https://babelmark.github.io/) to check markdown-to-html output of different rendering programs.


## Testing story
In curriculumbuilder repo root:
```bash
pipenv shell
./manage.py test curriculumBuilder    # run all tests in curriculumBuilder folder
./manage.py test    # run all tests
```

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
