### PR TITLE
Hardcode Common Sense Logo

### DIFF
--- a/curricula/templates/curricula/partials/lesson_front.html
+++ b/curricula/templates/curricula/partials/lesson_front.html
@@ -26,6 +26,15 @@
 <div class="together overview-page row">
 
     <div class="col-sm-7 left-col">
+        {% comment %}
+        lessons using the CREATIVE_COMMONS_BY_NC_ND_IMAGE image also need
+        the Common Sense Education logo above the overview
+        {% endcomment %}
+        {% if lesson.creative_commons_image == lesson.CREATIVE_COMMONS_BY_NC_ND_IMAGE %}
+            <a href="https://creativecommons.org/">
+                <img src="{% static "img/common_sense_education.png" %}" style="padding: 10px 0;">
+            </a> 
+        {% endif %}
         <h2>{% trans 'Overview' %}</h2>
         {% editable lesson.overview %}
             {{ lesson.overview|richtext_filters|safe }}

--- a/curriculumBuilder/local_settings.py.example
+++ b/curriculumBuilder/local_settings.py.example
@@ -7,9 +7,9 @@ DEBUG = True
 
 SLACK_BACKEND = 'django_slack.backends.DisabledBackend'
 
-# The following lines must be absent for unit tests to pass on linux,
-# but may need to be present for local changes to CSS to be visible in 
-# the browser.
+# Uncomment the following lines to serve static assets locally 
+# during development (e.g. CSS, images).
+# Note: These lines must be absent for unit tests to pass on linux.
 #
 # STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 # STATIC_URL = '/static/'


### PR DESCRIPTION
# Description

we need to hard-code the Common Sense Education logo above the overview for common sense lessons. we already have a sort of flag denoting those lessons, which is that they use a unique creative commons image. so rather than adding an additional flag to indicate the need for this hard-coded logo (which would need to stay in sync with the image choice), it was decided to use the image choice to determine the need for this logo.

<img width="925" alt="Screen Shot 2020-07-28 at 5 04 13 PM" src="https://user-images.githubusercontent.com/4986878/88847666-330fd380-d19c-11ea-9c96-73157c9b41b5.png">


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
### Deployment strategy

as soon as this PR is deployed, i will manually remove the image from the markdown in all the common sense lessons.

<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1504)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
