### PR TITLE
Allow the i18n sync process to detect changes, and skip publishing accordingly

### DIFF
--- a/i18n/management/commands/i18n_sync_down.py
+++ b/i18n/management/commands/i18n_sync_down.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     @staticmethod
     def download_translations():
         """Download translations from crowdin"""
-        Crowdin(etags_json="/tmp/cb_etags.json", changes_json="/tmp/cb_changes.json").download_translations()
+        Crowdin(etags_json="crowdin_etags.json").download_translations()
 
     def restore_translations(self):
         """Restore translations from source"""

--- a/i18n/management/commands/i18n_sync_down.py
+++ b/i18n/management/commands/i18n_sync_down.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     @staticmethod
     def download_translations():
         """Download translations from crowdin"""
-        Crowdin(etags_json="crowdin_etags.json").download_translations()
+        Crowdin().download_translations()
 
     def restore_translations(self):
         """Restore translations from source"""

--- a/i18n/management/commands/i18n_sync_down.py
+++ b/i18n/management/commands/i18n_sync_down.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     @staticmethod
     def download_translations():
         """Download translations from crowdin"""
-        Crowdin().download_translations()
+        Crowdin(etags_json="/tmp/cb_etags.json", changes_json="/tmp/cb_changes.json").download_translations()
 
     def restore_translations(self):
         """Restore translations from source"""

--- a/i18n/management/commands/i18n_sync_down.py
+++ b/i18n/management/commands/i18n_sync_down.py
@@ -8,6 +8,7 @@ from django.core.management.base import BaseCommand
 
 from i18n.management.utils import log, get_non_english_locale_names, get_models_to_sync
 from i18n.utils import I18nFileWrapper
+from i18n.management.crowdin import Crowdin
 
 
 class Command(BaseCommand):
@@ -16,11 +17,7 @@ class Command(BaseCommand):
     @staticmethod
     def download_translations():
         """Download translations from crowdin"""
-        subprocess.call([
-            os.path.join(I18nFileWrapper.i18n_dir(), 'heroku_crowdin.sh'),
-            "--config", os.path.join(I18nFileWrapper.i18n_dir(), "config", "crowdin.yml"),
-            "download"
-        ])
+        Crowdin().download_translations()
 
     def restore_translations(self):
         """Restore translations from source"""

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -1,43 +1,17 @@
 # pylint: disable=missing-docstring, broad-except
 import datetime
 import time
-import multiprocessing
+import json
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import translation
-from django import db
 
-from i18n.management.utils import log, get_models_to_sync
+from i18n.management.utils import log, get_models_to_sync, get_non_english_language_codes, CHANGES_JSON
 
 
 def can_publish_model(model):
     return hasattr(model, 'publish') or hasattr(model, 'publish_pdfs')
-
-
-def publish(obj):
-    if not obj.should_be_translated:
-        return
-
-    pdf_generation_time = 0
-
-    for language_code in Command.language_codes:
-        translation.activate(language_code)
-
-        if hasattr(obj, 'publish'):
-            list(obj.publish(silent=True))
-
-        if language_code in settings.LANGUAGE_GENERATE_PDF and hasattr(obj, 'publish_pdfs'):
-            try:
-                pdf_generation_start_time = time.time()
-                list(obj.publish_pdfs(silent=True))
-                pdf_generation_end_time = time.time()
-                pdf_generation_time += pdf_generation_end_time - pdf_generation_start_time
-            except Exception as err:
-                log(err)
-                log("PDF publishing failed %s in %s" % (obj.slug, language_code))
-
-    return pdf_generation_time
 
 
 class Command(BaseCommand):
@@ -47,16 +21,40 @@ class Command(BaseCommand):
         if can_publish_model(model)
     ]
 
-    language_codes = [
-        language_code for language_code, _ in settings.LANGUAGES
-        if language_code != settings.LANGUAGE_CODE
-    ]
-
     def __init__(self, *args, **kwargs):
         self.total_elapsed_time = 0
         self.total_pdf_generation_time = 0
 
+        with open(CHANGES_JSON) as changes_json:
+            self.changes = json.load(changes_json)
+
         super(Command, self).__init__(*args, **kwargs)
+
+    def has_changes(self, language_code):
+        # Because the published contents of a model include contents from other
+        # models, we can't easily determine whether a specific model should be
+        # published or not based on the changed files. So, we just determine
+        # changes on a per-language (rather than per-language and also
+        # per-model) basis. This should be sufficient for our needs given the
+        # relatively low translation activity for this project, but we may need
+        # to make this more sophisticated in the future if that changes.
+        return len(self.changes[language_code]) > 0
+
+    def publish_object(self, obj, language_code):
+        translation.activate(language_code)
+
+        if hasattr(obj, 'publish'):
+            list(obj.publish(silent=True))
+
+        if language_code in settings.LANGUAGE_GENERATE_PDF and hasattr(obj, 'publish_pdfs'):
+            try:
+                start_time = time.time()
+                list(obj.publish_pdfs(silent=True))
+                end_time = time.time()
+                self.total_pdf_generation_time += (end_time - start_time)
+            except Exception as err:
+                log(err)
+                log("PDF publishing failed %s in %s" % (obj.slug, language_code))
 
     def publish_models(self):
         """
@@ -64,7 +62,7 @@ class Command(BaseCommand):
         that define them
         """
         log("Models to publish: %s" % ', '.join(model.__name__ for model in self.models))
-        log("Languages to publish: %s" % ', '.join(self.language_codes))
+        log("Languages to publish: %s" % ', '.join(get_non_english_language_codes()))
 
         for model_index, model in enumerate(self.models):
             name = model.__name__
@@ -77,23 +75,25 @@ class Command(BaseCommand):
                 total
             ))
 
-            # By default, the spawned processes will attempt to reuse the existing database
-            # connections, which will cause conflicts. To prevent this, we explicitly close all
-            # database connections immediately before spawning the processes, which will force them
-            # to each open their own connection.
-            db.connections.close_all()
-
+            num_published = 0
             start_time = time.time()
-            results = multiprocessing.Pool(multiprocessing.cpu_count()).map(publish, objects.all())
+
+            for language_code in get_non_english_language_codes():
+                if not self.has_changes(language_code):
+                    continue
+                for obj in objects.all():
+                    if not obj.should_be_translated:
+                        continue
+                    self.publish_object(obj, language_code)
+                    num_published += 1
+
             end_time = time.time()
 
-            published_results = [result for result in results if result is not None]
             elapsed_time = (end_time - start_time)
             self.total_elapsed_time += elapsed_time
-            self.total_pdf_generation_time += sum(published_results)
 
             log("%s/%s %s objects published in %s" % (
-                len(published_results),
+                num_published,
                 total,
                 name,
                 datetime.timedelta(seconds=int(elapsed_time))
@@ -101,14 +101,15 @@ class Command(BaseCommand):
 
     def report_final_times(self):
         total_non_pdf_generation_time = self.total_elapsed_time - self.total_pdf_generation_time
+        num_languages = len(get_non_english_language_codes())
         log((
             "Publishing %s models in %s languages took %s total, %s not including PDF generation "
             "(average of ~%s per language). PDF generation took %s"
         ) % (
-            len(self.models), len(self.language_codes),
+            len(self.models), len(get_non_english_language_codes()),
             datetime.timedelta(seconds=int(self.total_elapsed_time)),
             datetime.timedelta(seconds=int(total_non_pdf_generation_time)),
-            datetime.timedelta(seconds=int(total_non_pdf_generation_time/len(self.language_codes))),
+            datetime.timedelta(seconds=int(total_non_pdf_generation_time/num_languages)),
             datetime.timedelta(seconds=int(self.total_pdf_generation_time))
         ))
 

--- a/i18n/management/crowdin.py
+++ b/i18n/management/crowdin.py
@@ -1,4 +1,3 @@
-# pylint: disable=superfluous-parens
 """
 Provides the Crowdin class, for all kinds of interaction with Crowdin data.
 """
@@ -14,8 +13,10 @@ from django.utils.translation import to_locale
 from .utils import get_non_english_language_codes, CHANGES_JSON
 from ..utils import I18nFileWrapper
 
-PROJECT_ID = 'curriculumbuilder'
 API_KEY = os.environ.get('CROWDIN_API_KEY')
+ETAGS_FILENAME = "crowdin_etags.json"
+PROJECT_ID = 'curriculumbuilder'
+
 
 # Crowdin sometimes uses four-letter language codes consistent with the language codes we use
 # internally, but sometimes uses other formats for its language codes. This constant provides a
@@ -38,9 +39,7 @@ class Crowdin(object):
     See https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/crowdin/project.rb for
     ruby implemntation
     """
-    def __init__(self, etags_json):
-        self.etags_json = etags_json
-
+    def __init__(self):
         self._project_info = None
         self._filepaths = None
 
@@ -56,7 +55,9 @@ class Crowdin(object):
             params = {}
 
         if API_KEY is None:
-            raise Exception("no API key found. Please make sure that CROWDIN_API_KEY is set in the local environment")
+            raise Exception(
+                "no API key found. Please make sure the CROWDIN_API_KEY environment variable is set"
+            )
 
         base_uri = "https://api.crowdin.com/api/project/" + PROJECT_ID
         default_params = {
@@ -149,7 +150,7 @@ class Crowdin(object):
 
             # Load existing etags from previous sync, if it exists
             etags = {}
-            etags_path = os.path.join(language_dir, self.etags_json)
+            etags_path = os.path.join(language_dir, ETAGS_FILENAME)
             if os.path.exists(etags_path):
                 self.logger.debug("loading existing etags from %s", etags_path)
                 with I18nFileWrapper.storage().open(etags_path, 'r') as etags_file:

--- a/i18n/management/crowdin.py
+++ b/i18n/management/crowdin.py
@@ -44,7 +44,7 @@ class Crowdin(object):
         self._project_info = None
         self._filepaths = None
 
-        self.logger = logging.getLogger(__name__)
+        self.logger = logging.getLogger('i18n')
 
     @staticmethod
     def request(method, endpoint, params=None, headers=None):

--- a/i18n/management/crowdin.py
+++ b/i18n/management/crowdin.py
@@ -1,0 +1,182 @@
+# pylint: disable=superfluous-parens
+"""
+Provides the Crowdin class, for all kinds of interaction with Crowdin data.
+"""
+
+import json
+import os
+import logging
+
+import requests
+
+PROJECT_ID = 'curriculumbuilder'
+API_KEY = os.environ.get('CROWDIN_API_KEY')
+
+
+class Crowdin(object):
+    """
+    This class provides access to data stored on Crowdin, via the Crowdin API.
+
+    See https://support.crowdin.com/api/ for API Reference
+    See https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/crowdin/project.rb for
+    ruby implemntation
+    """
+    def __init__(self):
+        self._project_info = None
+        self._filepaths = None
+        self._etags_json = "/tmp/cb_etags.json"
+        self._changes_json = "/tmp/cb_changes.json"
+
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.DEBUG)
+
+    @staticmethod
+    def request(method, endpoint, params=None, headers=None):
+        """
+        Make a request to the Crowdin API for this project, using the specified method, endpoint,
+        and parameteres.
+        """
+        if params is None:
+            params = {}
+
+        base_uri = "https://api.crowdin.com/api/project/" + PROJECT_ID
+        default_params = {
+            "key": API_KEY,
+            "json": True
+        }
+
+        params = dict(default_params.items() + params.items())
+        return getattr(requests, method)(
+            base_uri + "/" + endpoint,
+            params=params,
+            headers=headers
+        )
+
+    def info(self):
+        """
+        Retrieve project info from https://support.crowdin.com/api/info/. Cached.
+        """
+        if self._project_info is None:
+            self.logger.debug("Retrieving project info from Crowdin")
+            self._project_info = self.request('post', "info").json()
+        return self._project_info
+
+    def languages(self):
+        """
+        Retrieve list of all languages enabled for this project.
+        """
+        return self.info()["languages"]
+
+    def filepaths(self):
+        """
+        Retrieve list of all files currently uploaded to this project. Files will be presented as a
+        flat list of full filepaths.
+        """
+        if self._filepaths is None:
+            self.logger.debug("Retrieving list of files from Crowdin")
+            self._filepaths = []
+
+            def gather_filepaths(filenames, path=""):
+                """
+                Recursively iterate through the files and directories returned by the Crowdin API
+                call, gathering the results into a flat list.
+                """
+                for filename in filenames:
+                    name = filename["name"]
+                    filepath = os.path.join(path, name)
+                    if filename["node_type"] == "directory":
+                        subfilenames = filename["files"]
+                        gather_filepaths(subfilenames, filepath)
+                    elif filename["node_type"] == "file":
+                        self._filepaths.append(filepath)
+
+            gather_filepaths(self.info()["files"])
+
+        return self._filepaths
+
+    def export_file(self, filepath, language, etag=None):
+        """
+        Download the specified file in the specified language from crowdin. The etag argument can be
+        used to skip downloading a file if there are no changes.
+
+        See https://support.crowdin.com/api/export-file/
+        """
+        params = {
+            'file': filepath,
+            'language': language
+        }
+
+        headers = {}
+        if etag is not None:
+            headers["If-None-Match"] = etag
+
+        return self.request('get', 'export-file', params=params, headers=headers)
+
+    def download_translations(self):
+        """
+        Download all files with new translation activity since our last sync in all languages. In
+        addition to downloading updates to the files themselves, will also update our "etags" file,
+        which we use to identify file changes for future syncs, and our "changes" file, which we
+        will use in the sync out to identify which files got changed this sync.
+        """
+        # Load existing etags from previous sync
+        etags = {}
+        if os.path.exists(self._etags_json):
+            with open(self._etags_json, 'r') as etags_file:
+                etags = json.load(etags_file)
+
+        changes = dict()
+
+        # Download changes!
+        for i, language in enumerate(self.languages()):
+            language_code = language["code"]
+
+            self.logger.debug("{} ({}): {}/{}".format(
+                language['name'], language_code, i, len(self.languages())
+            ))
+            if i > 0 and i % (len(self.languages()) / 5) == 0:
+                self.logger.info("~{}% complete ({}/{})".format(
+                    (i * 100 / len(self.languages())), i, len(self.languages())
+                ))
+
+            download_dir = os.path.join("/tmp/cbsync", language_code)
+            if not os.path.exists(download_dir):
+                os.makedirs(download_dir)
+
+            changes[language_code] = []
+            if language_code not in etags:
+                etags[language_code] = {}
+
+            for filepath in self.filepaths():
+                etag = etags[language_code].get(filepath, None)
+                response = self.export_file(filepath, language_code, etag=etag)
+                if response.status_code == 200:
+                    # Add the file to our list of changed files
+                    changes[language_code].append(filepath)
+
+                    # Update the etag
+                    etags[language_code][filepath] = response.headers['etag']
+
+                    # Download the contents of the file
+                    with open(os.path.join(download_dir, filepath), 'w') as _file:
+                        _file.write(response.content)
+                elif response.status_code == 304:
+                    # 304 means there's no change (based on the etag), so we don't need to do
+                    # anything
+                    pass
+                else:
+                    raise Exception(
+                        "Cannot handle response code {} for file \"{}\" in language \"{}\"".format(
+                            response.status_code, filepath, language
+                        )
+                    )
+
+            self.logger.debug("{} files have changes".format(len(changes[language_code])))
+            with open(self._changes_json, 'w') as changes_file:
+                json.dump(changes, changes_file, sort_keys=True, indent=4)
+            with open(self._etags_json, 'w') as etags_file:
+                json.dump(etags, etags_file, sort_keys=True, indent=4)
+
+        self.logger.info("{} changed files downloaded across {} languages".format(
+            sum(len(files) for files in changes.items()), len(self.languages())
+        ))

--- a/i18n/management/crowdin.py
+++ b/i18n/management/crowdin.py
@@ -171,7 +171,10 @@ class Crowdin(object):
                     etags[language_code][filepath] = response.headers['etag']
 
                     # Persist the contents of the file
-                    with open(os.path.join(language_dir, filepath), 'w') as _file:
+                    full_filepath = os.path.join(language_dir, filepath)
+                    if not os.path.exists(os.path.dirname(full_filepath)):
+                        os.makedirs(os.path.dirname(full_filepath))
+                    with open(full_filepath, 'w') as _file:
                         _file.write(response.content)
                 elif response.status_code == 304:
                     # 304 means there's no change (based on the etag), so we don't need to do

--- a/i18n/management/utils.py
+++ b/i18n/management/utils.py
@@ -10,6 +10,8 @@ from django_slack import slack_message
 
 from i18n.models import Internationalizable
 
+CHANGES_JSON = "/tmp/crowdin_sync_latest_changes.json"
+
 
 def should_sync_model(model):
     """
@@ -19,12 +21,14 @@ def should_sync_model(model):
         - are not proxy models (unless the model explicitly opts in to translation)
     """
     is_internationalizable = issubclass(model, Internationalizable)
-    should_skip = model._meta.proxy and not getattr(model, 'translate_proxy', False) # pylint: disable=protected-access
+    should_skip = model._meta.proxy and not getattr(model, 'translate_proxy', False)  # pylint: disable=protected-access
     return is_internationalizable and not should_skip
+
 
 def get_models_to_sync():
     """Retrieve all models that should be processed by the i18n sync"""
     return [model for model in django.apps.apps.get_models() if should_sync_model(model)]
+
 
 def get_non_english_language_codes():
     """
@@ -35,6 +39,7 @@ def get_non_english_language_codes():
         language_code for language_code, _ in settings.LANGUAGES
         if not language_code == settings.LANGUAGE_CODE
     ]
+
 
 def get_non_english_locale_names():
     """

--- a/i18n/tests/test_crowdin.py
+++ b/i18n/tests/test_crowdin.py
@@ -1,0 +1,154 @@
+# pylint: disable=protected-access
+"""
+Contains tests for the Crowdin class, which provides access to the Crowdin API for the I18n sync
+"""
+import os
+import json
+
+from django.test import TestCase
+from django.utils.translation import to_locale
+from mock import patch
+from requests import Response
+
+from i18n.management.crowdin import Crowdin, ETAGS_FILENAME
+from i18n.management.utils import CHANGES_JSON
+from i18n.utils import I18nFileWrapper
+
+
+class CrowdinTest(TestCase):
+    """
+    Basic tests for the Crowdin class
+    """
+    def setUp(self):
+        self.crowdin = Crowdin()
+        self.crowdin._project_info = {
+            "files": [
+                {
+                    "node_type": "file",
+                    "name": "top-level file",
+                },
+                {
+                    "node_type": "directory",
+                    "name": "top-level directory",
+                    "files": [
+                        {
+                            "node_type": "file",
+                            "name": "nested file",
+                        },
+                        {
+                            "node_type": "directory",
+                            "name": "nested directory",
+                            "files": [
+                                {
+                                    "node_type": "file",
+                                    "name": "innermost file",
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+    def test_flattens_filepaths(self):
+        """
+        Test the ability of the 'gather filepaths' method to flatten the nested
+        structure returned by Crowdin
+        """
+        filepaths = self.crowdin.filepaths()
+        expected = [
+            'top-level file',
+            'top-level directory/nested file',
+            'top-level directory/nested directory/innermost file',
+        ]
+        self.assertEqual(filepaths, expected)
+
+    def test_updates_etags(self):
+        """
+        Test that the 'download translations' process will also persist the
+        updated etags for each file in each language
+        """
+        export_file_response = Response()
+        export_file_response.status_code = 200
+        export_file_response.headers['etag'] = "brand new etag"
+        export_file_response._content = ""
+
+        with patch.object(self.crowdin, 'export_file', return_value=export_file_response):
+            self.crowdin.download_translations()
+
+        language_dir = I18nFileWrapper.locale_dir_absolute(to_locale('es-mx'))
+        etags_path = os.path.join(language_dir, ETAGS_FILENAME)
+        with I18nFileWrapper.storage().open(etags_path, 'r') as etags_file:
+            etags = json.load(etags_file)
+            self.assertEqual(
+                etags["es-mx"]["top-level directory/nested directory/innermost file"],
+                "brand new etag"
+            )
+            self.assertEqual(etags["es-mx"]["top-level directory/nested file"], "brand new etag")
+            self.assertEqual(etags["es-mx"]["top-level file"], "brand new etag")
+
+        export_file_response.headers['etag'] = "even newer etag"
+        with patch.object(self.crowdin, 'export_file', return_value=export_file_response):
+            self.crowdin.download_translations()
+
+        with I18nFileWrapper.storage().open(etags_path, 'r') as etags_file:
+            etags = json.load(etags_file)
+            self.assertEqual(
+                etags["es-mx"]["top-level directory/nested directory/innermost file"],
+                "even newer etag"
+            )
+            self.assertEqual(etags["es-mx"]["top-level directory/nested file"], "even newer etag")
+            self.assertEqual(etags["es-mx"]["top-level file"], "even newer etag")
+
+    def test_saves_changes(self):
+        """
+        Test that the 'download translations' process will also persist a list
+        of changed files in each language
+        """
+        def mock_export_file(filepath, _language, etag=None):
+            """
+            mock the Crowdin.export_file method to return a '304 not modified'
+            for one of our expeced filepaths, and a '200 OK' for the others, so
+            our expected list of changes can exclude exactly that file
+            """
+            response = Response()
+            response.headers['etag'] = etag
+            if filepath == 'top-level directory/nested file':
+                response.status_code = 304
+            else:
+                response.status_code = 200
+            response._content = ""
+            return response
+
+        with patch.object(self.crowdin, 'export_file', mock_export_file):
+            self.crowdin.download_translations()
+        with open(CHANGES_JSON, 'r') as changes_json:
+            changes = json.load(changes_json)
+            self.assertEqual(changes.values()[0], [
+                'top-level file',
+                'top-level directory/nested directory/innermost file',
+            ])
+
+    def test_downloads_translations(self):
+        """
+        Test that the 'download translations' process will also persist the
+        updated files
+        """
+        def mock_export_file(filepath, _language, etag=None):
+            """
+            mock the Crowdin.export_file method to return unique content for
+            each path, so we can verify that the right content was written to
+            the right path.
+            """
+            response = Response()
+            response.headers['etag'] = etag
+            response.status_code = 200
+            response._content = "Content for '%s'" % filepath
+            return response
+
+        with patch.object(self.crowdin, 'export_file', mock_export_file):
+            self.crowdin.download_translations()
+
+        language_dir = I18nFileWrapper.locale_dir_absolute(to_locale('es-mx'))
+        with open(os.path.join(language_dir, 'top-level file'), 'r') as _file:
+            self.assertEqual(_file.read(), "Content for 'top-level file'")

--- a/i18n/tests/test_crowdin.py
+++ b/i18n/tests/test_crowdin.py
@@ -5,7 +5,7 @@ Contains tests for the Crowdin class, which provides access to the Crowdin API f
 import os
 import json
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils.translation import to_locale
 from mock import patch
 from requests import Response
@@ -15,6 +15,8 @@ from i18n.management.utils import CHANGES_JSON
 from i18n.utils import I18nFileWrapper
 
 
+@override_settings(I18N_STORAGE='django.core.files.storage.FileSystemStorage')
+@override_settings(I18N_STORAGE_LOCATION='i18n/static')
 class CrowdinTest(TestCase):
     """
     Basic tests for the Crowdin class


### PR DESCRIPTION
Inspired by [the similar changes](https://github.com/code-dot-org/code-dot-org/pull/34846) we recently made to the regular code.org repo.

This PR adds a new class which contains all the logic for interacting with Crowdin. It includes support for tracking etags for each file in each language and persists that data to S3 so it can be used by the next sync. It also generates a list of files changed by the most recent sync in each language (this file is not persisted); that list of changes is then used by the publish to entirely skip languages for which there were no changes.

We're unfortunately not able to skip publishing at a finer-grained level than "skip the entire language" given our current organization of data. Hopefully the fact that we have relatively frequent syncs and relatively low translation activity should mean that this somewhat clumsy approach is sufficient, but we'll have to try it and see!

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
- [jira](https://codedotorg.atlassian.net/browse/FND-1002)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
