### PR TITLE
use I18nFileWrapper for loading etags

### DIFF
--- a/i18n/management/crowdin.py
+++ b/i18n/management/crowdin.py
@@ -144,7 +144,7 @@ class Crowdin(object):
         for i, language_code in enumerate(get_non_english_language_codes()):
             self.logger.debug("%s: %s/%s", language_code, i + 1, len(language_codes))
 
-            language_dir = I18nFileWrapper.locale_dir(to_locale(language_code))
+            language_dir = I18nFileWrapper.locale_dir_absolute(to_locale(language_code))
             if not os.path.exists(language_dir):
                 os.makedirs(language_dir)
 

--- a/i18n/management/crowdin.py
+++ b/i18n/management/crowdin.py
@@ -144,14 +144,14 @@ class Crowdin(object):
         for i, language_code in enumerate(get_non_english_language_codes()):
             self.logger.debug("%s: %s/%s", language_code, i + 1, len(language_codes))
 
-            language_dir = I18nFileWrapper.locale_dir_absolute(to_locale(language_code))
+            language_dir = I18nFileWrapper.locale_dir(to_locale(language_code))
             if not os.path.exists(language_dir):
                 os.makedirs(language_dir)
 
             # Load existing etags from previous sync, if it exists
             etags = {}
             etags_path = os.path.join(language_dir, ETAGS_FILENAME)
-            if os.path.exists(etags_path):
+            if I18nFileWrapper.storage().exists(etags_path):
                 self.logger.debug("loading existing etags from %s", etags_path)
                 with I18nFileWrapper.storage().open(etags_path, 'r') as etags_file:
                     etags = json.load(etags_file)

--- a/i18n/tests/test_crowdin.py
+++ b/i18n/tests/test_crowdin.py
@@ -78,7 +78,7 @@ class CrowdinTest(TestCase):
         with patch.object(self.crowdin, 'export_file', return_value=export_file_response):
             self.crowdin.download_translations()
 
-        language_dir = I18nFileWrapper.locale_dir(to_locale('es-mx'))
+        language_dir = I18nFileWrapper.locale_dir_absolute(to_locale('es-mx'))
         etags_path = os.path.join(language_dir, ETAGS_FILENAME)
         with I18nFileWrapper.storage().open(etags_path, 'r') as etags_file:
             etags = json.load(etags_file)
@@ -151,6 +151,6 @@ class CrowdinTest(TestCase):
         with patch.object(self.crowdin, 'export_file', mock_export_file):
             self.crowdin.download_translations()
 
-        language_dir = I18nFileWrapper.locale_dir(to_locale('es-mx'))
+        language_dir = I18nFileWrapper.locale_dir_absolute(to_locale('es-mx'))
         with open(os.path.join(language_dir, 'top-level file'), 'r') as _file:
             self.assertEqual(_file.read(), "Content for 'top-level file'")

--- a/i18n/tests/test_crowdin.py
+++ b/i18n/tests/test_crowdin.py
@@ -78,7 +78,7 @@ class CrowdinTest(TestCase):
         with patch.object(self.crowdin, 'export_file', return_value=export_file_response):
             self.crowdin.download_translations()
 
-        language_dir = I18nFileWrapper.locale_dir_absolute(to_locale('es-mx'))
+        language_dir = I18nFileWrapper.locale_dir(to_locale('es-mx'))
         etags_path = os.path.join(language_dir, ETAGS_FILENAME)
         with I18nFileWrapper.storage().open(etags_path, 'r') as etags_file:
             etags = json.load(etags_file)
@@ -151,6 +151,6 @@ class CrowdinTest(TestCase):
         with patch.object(self.crowdin, 'export_file', mock_export_file):
             self.crowdin.download_translations()
 
-        language_dir = I18nFileWrapper.locale_dir_absolute(to_locale('es-mx'))
+        language_dir = I18nFileWrapper.locale_dir(to_locale('es-mx'))
         with open(os.path.join(language_dir, 'top-level file'), 'r') as _file:
             self.assertEqual(_file.read(), "Content for 'top-level file'")


### PR DESCRIPTION
# Description

Fix for the new sync approach defined in https://github.com/code-dot-org/curriculumbuilder/pull/305 to use the S3-compatible I18nFileWrapper for etag detection; as currently implemented, it won't find the etags file so we'll do a full sync each time.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
