### PR TITLE
more attempts to fix the S3 interaction for the i18n sync

### DIFF
--- a/i18n/tests/test_crowdin.py
+++ b/i18n/tests/test_crowdin.py
@@ -78,7 +78,7 @@ class CrowdinTest(TestCase):
         with patch.object(self.crowdin, 'export_file', return_value=export_file_response):
             self.crowdin.download_translations()
 
-        language_dir = I18nFileWrapper.locale_dir_absolute(to_locale('es-mx'))
+        language_dir = I18nFileWrapper.locale_dir(to_locale('es-mx'))
         etags_path = os.path.join(language_dir, ETAGS_FILENAME)
         with I18nFileWrapper.storage().open(etags_path, 'r') as etags_file:
             etags = json.load(etags_file)
@@ -151,6 +151,7 @@ class CrowdinTest(TestCase):
         with patch.object(self.crowdin, 'export_file', mock_export_file):
             self.crowdin.download_translations()
 
-        language_dir = I18nFileWrapper.locale_dir_absolute(to_locale('es-mx'))
-        with open(os.path.join(language_dir, 'top-level file'), 'r') as _file:
+        language_dir = I18nFileWrapper.locale_dir(to_locale('es-mx'))
+        file_path = os.path.join(language_dir, 'top-level file')
+        with I18nFileWrapper.storage().open(file_path, 'r') as _file:
             self.assertEqual(_file.read(), "Content for 'top-level file'")


### PR DESCRIPTION
The whole storage abstraction we have going on here is significantly more confusing than it needs to be.

So the way it works is the "absolute path" really only works for local filesystems; when we're using a virtual filesystem like we do in production, we need to use the relative path and also make sure to use the Storage-specific `open` operator rather than the OS-provided one.

We also need to be careful with how we handle creation of directories, since the whole concept of directories is itself filesystem specific and doesn't apply to S3.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
