### PR TITLE
Re-parallelize the publish operation

### DIFF
--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -73,10 +73,14 @@ class Command(BaseCommand):
         self.html_publishing_time += (end_time - start_time)
 
         if language_code in settings.LANGUAGE_GENERATE_PDF:
-            pdf_start_time = time.time()
-            self.pool.imap_unordered(publish_object_pdfs, objects.all())
-            pdf_end_time = time.time()
-            self.pdf_publishing_time += (pdf_end_time - pdf_start_time)
+            try:
+                pdf_start_time = time.time()
+                self.pool.imap_unordered(publish_object_pdfs, objects.all())
+                pdf_end_time = time.time()
+                self.pdf_publishing_time += (pdf_end_time - pdf_start_time)
+            except Exception as err:
+                log(err)
+                log("PDF publishing failed in %s" % language_code)
 
     def publish_models(self):
         """

--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -2,16 +2,28 @@
 import datetime
 import time
 import json
+import multiprocessing
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import translation
+from django import db
 
 from i18n.management.utils import log, get_models_to_sync, get_non_english_language_codes, CHANGES_JSON
 
 
 def can_publish_model(model):
     return hasattr(model, 'publish') or hasattr(model, 'publish_pdfs')
+
+
+def publish_object_html(obj):
+    if obj.should_be_translated and hasattr(obj, 'publish'):
+        list(obj.publish(silent=True))
+
+
+def publish_object_pdfs(obj):
+    if obj.should_be_translated and hasattr(obj, 'publish_pdfs'):
+        list(obj.publish_pdfs(silent=True))
 
 
 class Command(BaseCommand):
@@ -23,38 +35,48 @@ class Command(BaseCommand):
 
     def __init__(self, *args, **kwargs):
         self.total_elapsed_time = 0
-        self.total_pdf_generation_time = 0
+        self.pdf_publishing_time = 0
+        self.html_publishing_time = 0
+        self.pool = multiprocessing.Pool(multiprocessing.cpu_count())
 
         with open(CHANGES_JSON) as changes_json:
             self.changes = json.load(changes_json)
 
         super(Command, self).__init__(*args, **kwargs)
 
-    def has_changes(self, language_code):
-        # Because the published contents of a model include contents from other
-        # models, we can't easily determine whether a specific model should be
-        # published or not based on the changed files. So, we just determine
-        # changes on a per-language (rather than per-language and also
-        # per-model) basis. This should be sufficient for our needs given the
-        # relatively low translation activity for this project, but we may need
-        # to make this more sophisticated in the future if that changes.
-        return len(self.changes[language_code]) > 0
+    def get_language_codes_with_changes(self):
+        return [language_code for language_code
+                in get_non_english_language_codes()
+                if self.has_changes(language_code)]
 
-    def publish_object(self, obj, language_code):
+    def has_changes(self, language_code):
+        # Because the published contents of a model include contents from other models, we can't
+        # easily determine whether a specific model should be published or not based on the changed
+        # files. So, we just determine changes on a per-language (rather than per-language and also
+        # per-model) basis. This should be sufficient for our needs given the relatively low
+        # translation activity for this project, but we may need to make this more sophisticated in
+        # the future if that changes.
+        return len(self.changes.get(language_code, [])) > 0
+
+    def publish_objects_in_language(self, objects, language_code):
         translation.activate(language_code)
 
-        if hasattr(obj, 'publish'):
-            list(obj.publish(silent=True))
+        # By default, the spawned processes will attempt to reuse the existing database connections,
+        # which will cause conflicts. To prevent this, we explicitly close all database connections
+        # immediately before spawning the processes, which will force them to each open their own
+        # connection.
+        db.connections.close_all()
 
-        if language_code in settings.LANGUAGE_GENERATE_PDF and hasattr(obj, 'publish_pdfs'):
-            try:
-                start_time = time.time()
-                list(obj.publish_pdfs(silent=True))
-                end_time = time.time()
-                self.total_pdf_generation_time += (end_time - start_time)
-            except Exception as err:
-                log(err)
-                log("PDF publishing failed %s in %s" % (obj.slug, language_code))
+        start_time = time.time()
+        self.pool.imap_unordered(publish_object_html, objects.all())
+        end_time = time.time()
+        self.html_publishing_time += (end_time - start_time)
+
+        if language_code in settings.LANGUAGE_GENERATE_PDF:
+            pdf_start_time = time.time()
+            self.pool.imap_unordered(publish_object_pdfs, objects.all())
+            pdf_end_time = time.time()
+            self.pdf_publishing_time += (pdf_end_time - pdf_start_time)
 
     def publish_models(self):
         """
@@ -62,7 +84,7 @@ class Command(BaseCommand):
         that define them
         """
         log("Models to publish: %s" % ', '.join(model.__name__ for model in self.models))
-        log("Languages to publish: %s" % ', '.join(get_non_english_language_codes()))
+        log("Languages to publish: %s" % ', '.join(self.get_language_codes_with_changes()))
 
         for model_index, model in enumerate(self.models):
             name = model.__name__
@@ -74,43 +96,40 @@ class Command(BaseCommand):
                 len(self.models),
                 total
             ))
-
-            num_published = 0
             start_time = time.time()
 
-            for language_code in get_non_english_language_codes():
-                if not self.has_changes(language_code):
-                    continue
-                for obj in objects.all():
-                    if not obj.should_be_translated:
-                        continue
-                    self.publish_object(obj, language_code)
-                    num_published += 1
+            for language_code in self.get_language_codes_with_changes():
+                self.publish_objects_in_language(objects.all(), language_code)
 
             end_time = time.time()
-
             elapsed_time = (end_time - start_time)
             self.total_elapsed_time += elapsed_time
 
-            log("%s/%s %s objects published in %s" % (
-                num_published,
-                total,
+            log("%s objects published in %s" % (
                 name,
                 datetime.timedelta(seconds=int(elapsed_time))
             ))
 
     def report_final_times(self):
-        total_non_pdf_generation_time = self.total_elapsed_time - self.total_pdf_generation_time
-        num_languages = len(get_non_english_language_codes())
+        num_languages = len(self.get_language_codes_with_changes())
         log((
-            "Publishing %s models in %s languages took %s total, %s not including PDF generation "
-            "(average of ~%s per language). PDF generation took %s"
+            "Publishing %s models in %s languages took %s total (average of ~%s per language)"
         ) % (
-            len(self.models), len(get_non_english_language_codes()),
+            len(self.models), num_languages,
             datetime.timedelta(seconds=int(self.total_elapsed_time)),
-            datetime.timedelta(seconds=int(total_non_pdf_generation_time)),
-            datetime.timedelta(seconds=int(total_non_pdf_generation_time/num_languages)),
-            datetime.timedelta(seconds=int(self.total_pdf_generation_time))
+            datetime.timedelta(seconds=int(self.total_elapsed_time/num_languages)),
+        ))
+        log((
+            "HTML Publishing took %s total (average of ~%s per language)"
+        ) % (
+            datetime.timedelta(seconds=int(self.html_publishing_time)),
+            datetime.timedelta(seconds=int(self.html_publishing_time/num_languages)),
+        ))
+        log((
+            "PDF Publishing took %s total (average of ~%s per language)"
+        ) % (
+            datetime.timedelta(seconds=int(self.pdf_publishing_time)),
+            datetime.timedelta(seconds=int(self.pdf_publishing_time/num_languages)),
         ))
 
     def handle(self, *args, **options):


### PR DESCRIPTION
Also make it be a bit more explicit about exactly which languages it's publishing.

When we added the ability for the sync to skip publishing languages without translation changes in https://github.com/code-dot-org/curriculumbuilder/pull/305, we undid the parallelization stuff to get it to work. This PR reintroduces parallelization! We also update the time tracking and time reporting stuff to be a bit more explicit about exactly what's going on.