### PR TITLE
Use external source of truth for LANGUAGES setting

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -148,8 +148,9 @@ except Exception as exc:
     print("Could not retrieve list of languages from DynamoDB:")
     print(exc)
     LANGUAGES = (
-        (LANGUAGE_CODE, _('English')),
-        (LANGUAGE_CODE_DO_TRANSLATION, _('Translate')),
+        (LANGUAGE_CODE, 'English'),
+        ('es-mx', 'Mexican Spanish'),
+        (LANGUAGE_CODE_DO_TRANSLATION, 'Translate'),
     )
 
 # The subset of supported languages for which we support publishing PDFs


### PR DESCRIPTION
So that we can access this list of languages both from the CurriculumBuilder project (where we need it for the i18n sync) and from the Code.org project (where we need it for various display/linking operations)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

Tested manually

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
