### PR TITLE
log to slack when the i18n sync thinks we're operating on an incomplete list of languages

### DIFF
--- a/i18n/management/utils.py
+++ b/i18n/management/utils.py
@@ -35,10 +35,19 @@ def get_non_english_language_codes():
     Retrieve all language codes (ie "es-mx") for languages we need to process
     in the i18n sync.
     """
-    return [
+    language_codes = [
         language_code for language_code, _ in settings.LANGUAGES
         if not language_code == settings.LANGUAGE_CODE
     ]
+
+    # We dynamically retrieve the languages from DynamoDB at startup, so check
+    # here to make sure we got a full list. We default to a list containing
+    # just three languages, so we naively identify a "full list" by simply
+    # checking for a list longer than than.
+    if len(language_codes) <= 3:
+        log("Could not find full list of languages; using default")
+
+    return language_codes
 
 
 def get_non_english_locale_names():

--- a/i18n/middleware.py
+++ b/i18n/middleware.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.utils import translation
 from django.middleware.locale import LocaleMiddleware
 
+from management.utils import get_non_english_language_codes
+
 def get_language_from_path_strict(path, allowed_languages):
     for language_code in allowed_languages:
         if path.startswith('/{}/'.format(language_code)):
@@ -19,10 +21,7 @@ class StrictLocaleMiddleware(LocaleMiddleware):
     """
     def __init__(self):
         super(StrictLocaleMiddleware, self).__init__()
-        self.language_codes = [
-            language_code for language_code, _ in settings.LANGUAGES
-            if language_code != settings.LANGUAGE_CODE
-        ]
+        self.language_codes = get_non_english_language_codes()
 
     def process_request(self, request):
         language = get_language_from_path_strict(


### PR DESCRIPTION
follow-up from https://github.com/code-dot-org/curriculumbuilder/pull/313

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
