### PR TITLE
Addding the 'mock' dependency for unit tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 coverage==4.5.4
 django_coverage_plugin==1.6.0
-
+mock==3.0.5


### PR DESCRIPTION
I was setting up the curriculum builder for the first time and the unit tests failed because of a missing dependency.

## Testing story
`./manage.py test`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
