### PR TITLE
export stage_name and code_studio_url fields for lessons

### DIFF
--- a/curricula/serializers.py
+++ b/curricula/serializers.py
@@ -173,10 +173,11 @@ class LessonExportSerializer(serializers.ModelSerializer):
     teacher_desc = serializers.SerializerMethodField()
     student_desc = serializers.SerializerMethodField()
     activities = serializers.SerializerMethodField()
+    stage_name = serializers.SerializerMethodField()
 
     class Meta:
         model = Lesson
-        fields = ('title', 'number', 'student_desc', 'teacher_desc', 'activities', 'code_studio_url')
+        fields = ('title', 'number', 'student_desc', 'teacher_desc', 'activities', 'code_studio_url', 'stage_name')
 
     def get_teacher_desc(self, obj):
         return obj.overview
@@ -188,6 +189,11 @@ class LessonExportSerializer(serializers.ModelSerializer):
         activities = obj.activity_set.iterator()
         serializer = ActivityExportSerializer(activities, many=True, context=self.context)
         return serializer.data
+
+    def get_stage_name(self, obj):
+        if obj.stage:
+            return obj.stage['stageName']
+        return ''
 
 
 class ActivityExportSerializer(serializers.ModelSerializer):

--- a/curricula/serializers.py
+++ b/curricula/serializers.py
@@ -176,7 +176,7 @@ class LessonExportSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Lesson
-        fields = ('title', 'number', 'student_desc', 'teacher_desc', 'activities')
+        fields = ('title', 'number', 'student_desc', 'teacher_desc', 'activities', 'code_studio_url')
 
     def get_teacher_desc(self, obj):
         return obj.overview


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/curriculumbuilder/pull/319 . These fields are needed to match curriculum builder lessons to code studio lessons.