### PR TITLE
include unit export json when publishing a unit

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -404,6 +404,9 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
     def get_json_standards_url(self):
         return reverse('curriculum:unit_standards', args=[self.unit_name])
 
+    def get_json_export_url(self):
+        return reverse('curriculum:unit_export', args=[self.unit_name])
+
     def get_resources_pdf_url(self):
         return reverse('curriculum:unit_resources_pdf', args=[self.curriculum.slug, self.slug])
 
@@ -485,7 +488,8 @@ class Unit(InternationalizablePage, RichText, CloneableMixin, Ownable):
             self.get_standards_csv_url(),
             self.get_compiled_url(),
             self.get_json_url(),
-            self.get_json_standards_url()
+            self.get_json_standards_url(),
+            self.get_json_export_url()
         ]
         return urls
 


### PR DESCRIPTION
Finishes code changes for [PLAT-500](https://codedotorg.atlassian.net/browse/PLAT-500). After this is deployed, I'll need to go publish every unit in CSF / CSD / CSP 2020 before closing out the work item. This work is needed in order to be able to import cb data into an adhoc or levelbuilder without slowing down codecurricula.com for curriculum writers.

This PR copies the approach for publishing standards in https://github.com/code-dot-org/curriculumbuilder/pull/256.

## Testing story

I was not able to test publishing locally, so I performed some hand-wavy verification steps as best I could.

From http://localhost:8000/csf-20/coursea/ I clicked Publish in the admin menu. The debug output looked promising:

```
127.0.0.1 - - [11/Nov/2020 20:40:13] "GET /publish/?pk=5103&type=Unit&lessons=false HTTP/1.1" 200 -
...
RuntimeError: Error obtaining content for 10 out of 10 urls: [u'/csf-20/coursea/', u'/csf-20/coursea/resources/', u'/csf-20/coursea/code/', u'/csf-20/coursea/vocab/', u'/csf-20/coursea/standards/', u'/csf-20/coursea/standards.csv', u'/csf-20/coursea/compiled/', u'/metadata/coursea-2020.json', u'/metadata/coursea-2020/standards.json', u'/export/unit/coursea-2020.json']
```

The very last url in the list looks like it would point to the right place: https://www.codecurricula.com/export/unit/coursea-2020.json 

If you click on that link, you might be concerned to see that you get a prettified response, which isn't necessarily what you'd want to publish. however the same prettified style appears to be visible in the second to last url too: https://www.codecurricula.com/metadata/coursea-2020/standards.json

This makes me think that there is a pretty good chance this code change will result in being able to publish the unit export json files to codecurricula.com. I will verify after this PR is deployed and either fix forward or roll back if it does not go as expected.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
