### PR TITLE
Export Creative Commons license to import into Code Studio

### DIFF
--- a/curricula/serializers.py
+++ b/curricula/serializers.py
@@ -174,10 +174,11 @@ class LessonExportSerializer(serializers.ModelSerializer):
     student_desc = serializers.SerializerMethodField()
     activities = serializers.SerializerMethodField()
     stage_name = serializers.SerializerMethodField()
+    creative_commons_license = serializers.SerializerMethodField()
 
     class Meta:
         model = Lesson
-        fields = ('title', 'number', 'student_desc', 'teacher_desc', 'activities', 'code_studio_url', 'stage_name')
+        fields = ('title', 'number', 'student_desc', 'teacher_desc', 'activities', 'code_studio_url', 'stage_name', 'creative_commons_license')
 
     def get_teacher_desc(self, obj):
         return obj.overview
@@ -194,6 +195,13 @@ class LessonExportSerializer(serializers.ModelSerializer):
         if obj.stage:
             return obj.stage['stageName']
         return ''
+
+    def get_creative_commons_license(self, obj):
+        img_to_license = {
+            'img/creativeCommons-by-nc-sa.png': 'Creative Commons BY-NC-SA',
+            'img/creativeCommons-by-nc-nd.png': 'Creative Commons BY-NC-ND'
+        }
+        return img_to_license[obj.creative_commons_image]
 
 
 class ActivityExportSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Unfortunately, the image path is stored for each lesson so I had to reverse the logic [here](https://github.com/code-dot-org/curriculumbuilder/blob/a2b92677069aa5deae0726ead47fa70e2399e50a/lessons/models.py#L353) to get the actual license name. I did a quick spot check and these strings match the ones we expect in code studio.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
