### PR TITLE
include resources in lesson export

### DIFF
--- a/curricula/serializers.py
+++ b/curricula/serializers.py
@@ -173,13 +173,14 @@ class LessonExportSerializer(serializers.ModelSerializer):
     teacher_desc = serializers.SerializerMethodField()
     student_desc = serializers.SerializerMethodField()
     activities = serializers.SerializerMethodField()
+    resources = serializers.SerializerMethodField()
     objectives = serializers.SerializerMethodField()
     stage_name = serializers.SerializerMethodField()
     creative_commons_license = serializers.SerializerMethodField()
 
     class Meta:
         model = Lesson
-        fields = ('title', 'number', 'student_desc', 'teacher_desc', 'activities', 'objectives', 'code_studio_url', 'stage_name', 'prep', 'cs_content', 'creative_commons_license')
+        fields = ('title', 'number', 'student_desc', 'teacher_desc', 'activities', 'resources', 'objectives', 'code_studio_url', 'stage_name', 'prep', 'cs_content', 'creative_commons_license')
 
     def get_teacher_desc(self, obj):
         return obj.overview
@@ -190,6 +191,11 @@ class LessonExportSerializer(serializers.ModelSerializer):
     def get_activities(self, obj):
         activities = obj.activity_set.iterator()
         serializer = ActivityExportSerializer(activities, many=True, context=self.context)
+        return serializer.data
+
+    def get_resources(self, obj):
+        resources = obj.resources
+        serializer = ResourceExportSerializer(resources, many=True, context=self.context)
         return serializer.data
 
     def get_objectives(self, obj):
@@ -217,6 +223,13 @@ class ActivityExportSerializer(serializers.ModelSerializer):
 
     def get_duration(self, obj):
         return obj.time
+
+
+class ResourceExportSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Resource
+        fields = ('name', 'type', 'student', 'gd', 'url', 'dl_url', 'slug')
+
 
 
 """


### PR DESCRIPTION
Starts [PLAT-517](https://codedotorg.atlassian.net/browse/PLAT-517). Adds resources to each exported lesson. The list of exported fields roughly covers all of the columns and properties on the Resource model, except for internal rails ids.

## Testing story

new fields appear to be populated:

![Screen Shot 2020-11-17 at 2 40 36 PM](https://user-images.githubusercontent.com/8001765/99459623-411c6800-28e3-11eb-96e9-6855685cdc4d.png)

![Screen Shot 2020-11-17 at 2 43 41 PM](https://user-images.githubusercontent.com/8001765/99459672-52657480-28e3-11eb-893d-17cadb68bb4c.png)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
