### PR TITLE
Adding the 'slug' attribute for Lessons in the Admin panel

### DIFF
--- a/lessons/admin.py
+++ b/lessons/admin.py
@@ -328,7 +328,7 @@ class LessonAdmin(PageAdmin, AjaxSelectAdmin, CompareVersionAdmin, FilterableAdm
         fieldsets = (
             (None, {
                 'fields': ['title', 'short_title', status_fields, 'image',
-                           'overview', 'keywords', ('description', 'gen_description'), 'code_studio_url'],
+                           'overview', 'slug', 'keywords', ('description', 'gen_description'), 'code_studio_url'],
             }),
             ('Assessment', {
                 'fields': ['assessment'],


### PR DESCRIPTION
# Description
Adding the `slug` attribute to the Admin panel for the Lesson model. This is helpful because currently the `slug` is used by the i18n system as the "key" for looking up the Lesson's translations. Having this field available for viewing and editing will enable us to quickly debug issues where different lessons accidentally have the same/wrong `slug`.

## Testing story
* Manually tested on localhost
  * http://localhost-studio.code.org:8000/admin/lessons/lesson/2640/

## Screenshots
![image](https://user-images.githubusercontent.com/1372238/101207703-e74cc980-3668-11eb-93df-a9e40e32e560.png)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
