### PR TITLE
adding a warning for Heroku CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ To update your local database schema use the following command:
 dropdb curriculumbuilder
 heroku pg:pull DATABASE_URL curriculumbuilder -a curriculumbuilder
 ```
+NOTE: avoid using commands that include the `DATABASE_URL` flag, apart from `pg:pull`. This flag allows users to directly manipulate the production database from the command line and should be used with caution.
 
 ### Creating a new user
 


### PR DESCRIPTION
Adding a Readme warning for users to avoid using Heroku CLI commands that may unintentionally manipulate the production database.

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
