### PR TITLE
Add a basic "language select" dropdown

### DIFF
--- a/curricula/templates/curricula/partials/footer.html
+++ b/curricula/templates/curricula/partials/footer.html
@@ -4,11 +4,19 @@
 <footer>
   <div class="container">
     <div class="row">
-      {% if lesson %}
-        <a href="https://creativecommons.org/"><img src="{% static lesson.creative_commons_image %}" border="0"></a><br/>
-      {% else %}
-        <a href="https://creativecommons.org/"><img src="{% static "img/creativeCommons-by-nc-sa.png" %}" border="0"></a><br/>
-      {% endif %}
+      <a href="https://creativecommons.org/" style="float: left">
+        {% if lesson %}
+          <img src="{% static lesson.creative_commons_image %}" border="0">
+        {% else %}
+          <img src="{% static "img/creativeCommons-by-nc-sa.png" %}" border="0">
+        {% endif %}
+      </a>
+
+      <div style="float: right; position: relative;">
+        {% include "curricula/partials/language_select.html" %}
+      </div>
+    </div>
+    <div class="row">
       <span class="license">{{ license|richtext_filters|safe }}</span>
     </div>
   </div>

--- a/curricula/templates/curricula/partials/language_select.html
+++ b/curricula/templates/curricula/partials/language_select.html
@@ -1,0 +1,14 @@
+<div class="language-dropdown" style="position: relative; top: 10px;">
+  <select onchange="window.location.assign('/' + this.value + '{{ CURRENT_PATH_WITHOUT_LANGUAGE }}');">
+    {% for code, name in LANGUAGES %}
+      {% if code != LANGUAGE_CODE_DO_TRANSLATION %}
+        <option
+          value="{{ code }}"
+          {% if code == LANGUAGE_CODE %}selected=""{% endif %}
+        >
+          {{ name }}
+        </option>
+      {% endif %}
+    {% endfor %}
+  </select>
+</div>

--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
 import boto3
@@ -149,7 +150,7 @@ except Exception as exc:
     print(exc)
     LANGUAGES = (
         (LANGUAGE_CODE, 'English'),
-        ('es-mx', 'Mexican Spanish'),
+        ('es-mx', 'Español (LATAM)'),
         (LANGUAGE_CODE_DO_TRANSLATION, 'Translate'),
     )
 
@@ -351,7 +352,8 @@ TEMPLATES = [{u'APP_DIRS': False,
                                           u'django.core.context_processors.tz',
                                           u'mezzanine.conf.context_processors.settings',
                                           u'mezzanine.pages.context_processors.page',
-                                          u'i18n.context_processors.language_code_do_translation'),
+                                          u'i18n.context_processors.language_code_do_translation',
+                                          u'i18n.context_processors.current_path_without_language'),
                   u'loaders': [(u'django.template.loaders.cached.Loader',
                                (u'django.template.loaders.filesystem.Loader',
                                 u'django.template.loaders.app_directories.Loader'))],

--- a/i18n/context_processors.py
+++ b/i18n/context_processors.py
@@ -1,4 +1,16 @@
 from django.conf import settings
 
+
 def language_code_do_translation(request):
     return {'LANGUAGE_CODE_DO_TRANSLATION': settings.LANGUAGE_CODE_DO_TRANSLATION}
+
+
+def current_path_without_language(request):
+    current_path = request.get_full_path()
+    current_language = request.LANGUAGE_CODE
+    current_language_prefix = "/" + current_language
+
+    if current_path.startswith(current_language_prefix):
+        return {'CURRENT_PATH_WITHOUT_LANGUAGE': current_path[len(current_language_prefix):]}
+    else:
+        return {'CURRENT_PATH_WITHOUT_LANGUAGE': current_path}

--- a/i18n/management/utils.py
+++ b/i18n/management/utils.py
@@ -4,6 +4,7 @@ Helper methods for use during the i18n sync process
 import django.apps
 
 from django.conf import settings
+from django.template.base import TemplateDoesNotExist
 from django.utils.translation import to_locale
 
 from django_slack import slack_message
@@ -67,6 +68,11 @@ def log(message):
     for actual use.
     """
     print(message) # pylint: disable=superfluous-parens
-    slack_message('slack/message.slack', {
-        'message': message
-    })
+    try:
+        slack_message('slack/message.slack', {
+            'message': message
+        })
+    except TemplateDoesNotExist:
+        # This is silly, but when trying to test requests we run into issues
+        # because the message template is not loaded in our test environment.
+        pass

--- a/i18n/tests/test_context_processors.py
+++ b/i18n/tests/test_context_processors.py
@@ -1,0 +1,37 @@
+"""
+Tests for the custom i18n context processors
+"""
+from django.test import TestCase
+
+
+class CurrentPathWithoutLanguageContextProcessorTests(TestCase):
+    """
+    Tests for the ``i18n.context_processors.current_path_without_language`` processor.
+    """
+
+    def test_standard_url(self):
+        """
+        Test that we don't alter a url without a language prefix
+        """
+        url = '/hoc/plugged/'
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.context["request_path"], "/en-us/hoc/plugged/")
+        self.assertEqual(response.context["CURRENT_PATH_WITHOUT_LANGUAGE"], "/hoc/plugged/")
+
+    def test_english_url(self):
+        """
+        Test that we do alter a url which explicitly specifies english
+        """
+        url = '/en-us/hoc/plugged/'
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.context["request_path"], "/en-us/hoc/plugged/")
+        self.assertEqual(response.context["CURRENT_PATH_WITHOUT_LANGUAGE"], "/hoc/plugged/")
+
+    def test_nonenglish_url(self):
+        """
+        Test that we do alter a url which explicitly specifies a nonenglish language
+        """
+        url = '/es-mx/hoc/plugged/'
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.context["request_path"], "/es-mx/hoc/plugged/")
+        self.assertEqual(response.context["CURRENT_PATH_WITHOUT_LANGUAGE"], "/hoc/plugged/")


### PR DESCRIPTION
# Description

Looks like this:

![image](https://user-images.githubusercontent.com/244100/101820188-1b960f00-3adb-11eb-896e-1bdb68541391.png)

Works like you'd expect.

### BEFORE MERGING

Right now, it displays all languages in English. To improve this experience, we should go into DynamoDB and set the language names as defined in there to display each language name in its own language (as we do for the code.org language select dropdown). Out of an abundance of caution, I'm going to hold off on making that data change (and merging this PR) until after Hour of Code.

## Testing story

Added a basic unit test. Could theoretically add a UI test of some kind, but that seems unnecessary. Open to suggestions if y'all feel otherwise.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
