### PR TITLE
Adding the Crowdin language code mapping for Uzbek

### DIFF
--- a/i18n/management/crowdin.py
+++ b/i18n/management/crowdin.py
@@ -21,6 +21,7 @@ PROJECT_ID = 'curriculumbuilder'
 # Crowdin sometimes uses four-letter language codes consistent with the language codes we use
 # internally, but sometimes uses other formats for its language codes. This constant provides a
 # mapping from our codes to Crowdin's for those cases for which they differ.
+# https://support.crowdin.com/api/language-codes/
 CROWDIN_LANGUAGE_CODES = {
     'ar-sa': 'ar',
     'fr-fr': 'fr',
@@ -29,7 +30,8 @@ CROWDIN_LANGUAGE_CODES = {
     'pl-pl': 'pl',
     'sk-sk': 'sk',
     'th-th': 'th',
-    'in-tl': 'in'
+    'in-tl': 'in',
+    'uz-uz': 'uz'
 }
 
 


### PR DESCRIPTION
# Description
The i18n-down-sync failed on Curriculum builder because it failed to find the translations for `uz-uz` which is the new Uzbek language. It failed to find the translation on Crowdin because Crowdin uses the language code`uz`. This PR adds the mapping of `uz-uz` to `uz`.

## Error log
```
20.         Crowdin().download_translations()
File "/app/i18n/management/crowdin.py" in download_translations
 197.                             response.status_code, filepath, language_code
Exception Type: Exception
Exception Value: Cannot handle response code 404 for file "Curriculum.json" in language "uz-uz"
Request data not supplied
```

## Testing story
* ran `./manage.py i18n_sync_down` on my laptop

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
