### PR TITLE
setting storage location to i18n/static by default

### DIFF
--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -14,8 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 from urlparse import urlparse
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-I18N_DIR = os.path.join(BASE_DIR, "i18n")
-I18N_STATIC_DIR = os.path.join(I18N_DIR, "static")
+I18N_STORAGE_LOCATION = os.path.join("i18n", "static")
 
 ######################
 # MEZZANINE SETTINGS #
@@ -164,7 +163,7 @@ LANGUAGE_GENERATE_PDF = (
 )
 
 LOCALE_PATHS = (
-    os.path.join(I18N_STATIC_DIR, 'translations/'),
+    os.path.join(BASE_DIR, I18N_STORAGE_LOCATION, 'translations/'),
 )
 
 
@@ -554,7 +553,7 @@ AWS_QUERYSTRING_AUTH = False
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 AWS_SESSION_TOKEN = os.environ.get('AWS_SESSION_TOKEN')
-AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME') or 'cdo-curriculum'
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME') or 'cdo-curriculum-devel'
 # AWS_S3_CUSTOM_DOMAIN = '%s.s3.amazonaws.com' % AWS_STORAGE_BUCKET_NAME
 AWS_S3_CUSTOM_DOMAIN = 'curriculum.code.org'
 AWS_PRELOAD_METADATA = True  # helps collectstatic do updates
@@ -572,7 +571,7 @@ MEDIAFILES_LOCATION = 'media'
 DEFAULT_FILE_STORAGE = 'helpers.s3utils.MediaRootS3BotoStorage'
 MEDIA_URL = "https://%s/%s/" % (AWS_S3_CUSTOM_DOMAIN, MEDIAFILES_LOCATION)
 
-I18N_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+I18N_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
 # STATIC_URL = 'https://' + AWS_STORAGE_BUCKET_NAME + '.s3.amazonaws.com/static/'
 # ADMIN_MEDIA_PREFIX = STATIC_URL + 'grappelli/'

--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -553,7 +553,7 @@ AWS_QUERYSTRING_AUTH = False
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 AWS_SESSION_TOKEN = os.environ.get('AWS_SESSION_TOKEN')
-AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME') or 'cdo-curriculum-devel'
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME') or 'cdo-curriculum'
 # AWS_S3_CUSTOM_DOMAIN = '%s.s3.amazonaws.com' % AWS_STORAGE_BUCKET_NAME
 AWS_S3_CUSTOM_DOMAIN = 'curriculum.code.org'
 AWS_PRELOAD_METADATA = True  # helps collectstatic do updates
@@ -571,7 +571,7 @@ MEDIAFILES_LOCATION = 'media'
 DEFAULT_FILE_STORAGE = 'helpers.s3utils.MediaRootS3BotoStorage'
 MEDIA_URL = "https://%s/%s/" % (AWS_S3_CUSTOM_DOMAIN, MEDIAFILES_LOCATION)
 
-I18N_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+I18N_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
 # STATIC_URL = 'https://' + AWS_STORAGE_BUCKET_NAME + '.s3.amazonaws.com/static/'
 # ADMIN_MEDIA_PREFIX = STATIC_URL + 'grappelli/'

--- a/curriculumBuilder/settings.py
+++ b/curriculumBuilder/settings.py
@@ -14,7 +14,8 @@ from django.utils.translation import ugettext_lazy as _
 from urlparse import urlparse
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-I18N_STATIC_DIR = os.path.join(BASE_DIR, "i18n", "static")
+I18N_DIR = os.path.join(BASE_DIR, "i18n")
+I18N_STATIC_DIR = os.path.join(I18N_DIR, "static")
 
 ######################
 # MEZZANINE SETTINGS #

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -23,11 +23,14 @@ class I18nFileWrapper:
 
     @classmethod
     def i18n_dir(cls):
-        return settings.I18N_DIR
+        static = "/static"
+        if static in cls.storage().location:
+            return cls.storage().location.replace(static, "")
+        return cls.storage().location
 
     @classmethod
     def static_dir(cls):
-        return settings.I18N_STATIC_DIR
+        return os.path.join(cls.i18n_dir(), 'static')
 
     @classmethod
     def locale_dir(cls, locale_name):
@@ -94,5 +97,5 @@ class I18nFileWrapper:
         if cls._storage is None:
             storage = getattr(settings, 'I18N_STORAGE', 'django.core.files.storage.FileSystemStorage')
             storage_cls = import_string(storage)
-            cls._storage = storage_cls(location=getattr(settings, 'I18N_STORAGE_LOCATION', 'i18n/static'))
+            cls._storage = storage_cls(location=getattr(settings, 'I18N_STORAGE_LOCATION', 'i18n'))
         return cls._storage

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -23,11 +23,11 @@ class I18nFileWrapper:
 
     @classmethod
     def i18n_dir(cls):
-        return os.path.dirname(__file__)
+        return settings.I18N_DIR
 
     @classmethod
     def static_dir(cls):
-        return os.path.join(cls.i18n_dir(), 'static')
+        return settings.I18N_STATIC_DIR
 
     @classmethod
     def locale_dir(cls, locale_name):

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -94,5 +94,5 @@ class I18nFileWrapper:
         if cls._storage is None:
             storage = getattr(settings, 'I18N_STORAGE', 'django.core.files.storage.FileSystemStorage')
             storage_cls = import_string(storage)
-            cls._storage = storage_cls(location=getattr(settings, 'I18N_STORAGE_LOCATION', 'i18n'))
+            cls._storage = storage_cls(location=getattr(settings, 'I18N_STORAGE_LOCATION', 'i18n/static'))
         return cls._storage

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -23,10 +23,7 @@ class I18nFileWrapper:
 
     @classmethod
     def i18n_dir(cls):
-        static = "/static"
-        if static in cls.storage().location:
-            return cls.storage().location.replace(static, "")
-        return cls.storage().location
+        return os.path.dirname(__file__)
 
     @classmethod
     def static_dir(cls):


### PR DESCRIPTION
# Description

Problem summary: the CB i18n-sync reads from the` i18n/static/translations` directory, but it writes to the `i18n/translations` directory. Thus, CB translations have not been updated since August 2020.

This change adjusts the default storage location to `i18n/static` instead of `i18n` so that the sync-down uploads files to the same directory that CB reads translations from

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&modal=detail&selectedIssue=FND-1328)

## Testing story

Tested the sync-down script both locally and to the `cdo-curriculum-devel` S3 bucket to ensure correct upload. Verified locally that new translations show up (UI element translations are the most obvious giveaway)

Before:
<img width="1032" alt="Screen Shot 2021-01-22 at 1 18 46 PM" src="https://user-images.githubusercontent.com/16494556/105548407-6b5c1e80-5cb4-11eb-9cb2-503182dce015.png">

After:
<img width="1074" alt="Screen Shot 2021-01-22 at 1 19 03 PM" src="https://user-images.githubusercontent.com/16494556/105548420-70b96900-5cb4-11eb-810a-258623088d05.png">


<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
