### PR TITLE
adding python script to locally download django.po and .mo files in CB

### DIFF
--- a/i18n/management/commands/i18n_message_file_sync.py
+++ b/i18n/management/commands/i18n_message_file_sync.py
@@ -1,0 +1,86 @@
+# pylint: disable=missing-docstring
+import glob
+import os
+import json
+
+from django.core import management
+from django.core.management.base import BaseCommand
+from django.utils.translation import to_locale
+from django.core.files.storage import FileSystemStorage
+
+from i18n.management.crowdin import Crowdin
+from i18n.management.utils import log, get_non_english_language_codes
+from i18n.utils import I18nFileWrapper
+
+
+class Command(BaseCommand):
+
+    # Retrieves all django.po files from Crowdin and
+    # saves them locally
+    def download_message_file(self):
+        # Download changes!
+        for language_code in get_non_english_language_codes():
+
+            locale = to_locale(language_code)
+            language_dir = I18nFileWrapper.locale_dir_absolute(locale)
+            if not os.path.exists(language_dir):
+                os.makedirs(language_dir)
+
+            # Load existing etags from previous sync, if it exists.
+            # Note that here we're using locale_dir and not locale_dir_absolute; we want to
+            # specifically retrieve the etags from wherever they are persisted, even if that's not
+            # the local filesystem.
+            etags = {}
+            etags_path = os.path.join(I18nFileWrapper.locale_dir(locale), "crowdin_etags.json")
+            if I18nFileWrapper.storage().exists(etags_path):
+                log("loading existing etags from %s" % etags_path)
+                with I18nFileWrapper.storage().open(etags_path, 'r') as etags_file:
+                    etags = json.load(etags_file)
+
+            if language_code not in etags:
+                etags[language_code] = {}
+
+            filepath = "django.po"
+            etag = etags[language_code].get(filepath, None)
+            response = Crowdin().export_file(filepath, language_code, etag=etag)
+            if response.status_code == 200:
+
+                # Update the etag for this file, for use in the next sync
+                etags[language_code][filepath] = response.headers['etag']
+
+                # Persist the contents of the file.
+                # Although we have access to the I18nFileWrapper here and could persist the
+                # contents directly to S3, we actually need them on the local filesystem so we
+                # can restore them; other parts of the sync process will handle uploading the
+                # files to S3.
+                full_filepath = os.path.join(language_dir, filepath)
+                if not os.path.exists(os.path.dirname(full_filepath)):
+                    os.makedirs(os.path.dirname(full_filepath))
+
+                with open(full_filepath, 'w') as _file:
+                    _file.write(response.content)
+            elif response.status_code == 304:
+                # 304 means there's no change (based on the etag), so we don't need to do
+                # anything
+                pass
+            else:
+                raise Exception(
+                    "Cannot handle response code {} for file \"{}\" in language \"{}\"".format(
+                        response.status_code, filepath, language_code
+                    )
+                )
+
+            storage_etags_path = os.path.join(str(I18nFileWrapper.storage().location), I18nFileWrapper.locale_dir(locale))
+            if isinstance(I18nFileWrapper.storage(), FileSystemStorage) and not os.path.exists(storage_etags_path):
+                os.makedirs(storage_etags_path)
+            with I18nFileWrapper.storage().open(etags_path, 'w') as etags_file:
+                json.dump(etags, etags_file, sort_keys=True, indent=4)
+
+    def handle(self, *args, **options):
+        log("Checking for updates in django.po")
+        try:
+            self.download_message_file()
+            management.call_command("compilemessages")
+        except Exception as err:
+            log(err)
+            raise

--- a/i18n/management/commands/i18n_message_file_sync.py
+++ b/i18n/management/commands/i18n_message_file_sync.py
@@ -5,81 +5,16 @@ import json
 
 from django.core import management
 from django.core.management.base import BaseCommand
-from django.utils.translation import to_locale
-from django.core.files.storage import FileSystemStorage
 
 from i18n.management.crowdin import Crowdin
-from i18n.management.utils import log, get_non_english_language_codes
-from i18n.utils import I18nFileWrapper
-
+from i18n.management.utils import log
 
 class Command(BaseCommand):
-
-    # Retrieves all django.po files from Crowdin and
-    # saves them locally
-    def download_message_file(self):
-        # Download changes!
-        for language_code in get_non_english_language_codes():
-
-            locale = to_locale(language_code)
-            language_dir = I18nFileWrapper.locale_dir_absolute(locale)
-            if not os.path.exists(language_dir):
-                os.makedirs(language_dir)
-
-            # Load existing etags from previous sync, if it exists.
-            # Note that here we're using locale_dir and not locale_dir_absolute; we want to
-            # specifically retrieve the etags from wherever they are persisted, even if that's not
-            # the local filesystem.
-            etags = {}
-            etags_path = os.path.join(I18nFileWrapper.locale_dir(locale), "crowdin_etags.json")
-            if I18nFileWrapper.storage().exists(etags_path):
-                log("loading existing etags from %s" % etags_path)
-                with I18nFileWrapper.storage().open(etags_path, 'r') as etags_file:
-                    etags = json.load(etags_file)
-
-            if language_code not in etags:
-                etags[language_code] = {}
-
-            filepath = "django.po"
-            etag = etags[language_code].get(filepath, None)
-            response = Crowdin().export_file(filepath, language_code, etag=etag)
-            if response.status_code == 200:
-
-                # Update the etag for this file, for use in the next sync
-                etags[language_code][filepath] = response.headers['etag']
-
-                # Persist the contents of the file.
-                # Although we have access to the I18nFileWrapper here and could persist the
-                # contents directly to S3, we actually need them on the local filesystem so we
-                # can restore them; other parts of the sync process will handle uploading the
-                # files to S3.
-                full_filepath = os.path.join(language_dir, filepath)
-                if not os.path.exists(os.path.dirname(full_filepath)):
-                    os.makedirs(os.path.dirname(full_filepath))
-
-                with open(full_filepath, 'w') as _file:
-                    _file.write(response.content)
-            elif response.status_code == 304:
-                # 304 means there's no change (based on the etag), so we don't need to do
-                # anything
-                pass
-            else:
-                raise Exception(
-                    "Cannot handle response code {} for file \"{}\" in language \"{}\"".format(
-                        response.status_code, filepath, language_code
-                    )
-                )
-
-            storage_etags_path = os.path.join(str(I18nFileWrapper.storage().location), I18nFileWrapper.locale_dir(locale))
-            if isinstance(I18nFileWrapper.storage(), FileSystemStorage) and not os.path.exists(storage_etags_path):
-                os.makedirs(storage_etags_path)
-            with I18nFileWrapper.storage().open(etags_path, 'w') as etags_file:
-                json.dump(etags, etags_file, sort_keys=True, indent=4)
 
     def handle(self, *args, **options):
         log("Checking for updates in django.po")
         try:
-            self.download_message_file()
+            Crowdin().download_translations(["django.po"])
             management.call_command("compilemessages")
         except Exception as err:
             log(err)

--- a/i18n/management/crowdin.py
+++ b/i18n/management/crowdin.py
@@ -134,7 +134,7 @@ class Crowdin(object):
 
         return self.request('get', 'export-file', params=params, headers=headers)
 
-    def download_translations(self):
+    def download_translations(self, filepaths = None):
         """
         Download all files with new translation activity since our last sync in all languages. In
         addition to downloading updates to the files themselves, will also update our "etags" file,
@@ -169,7 +169,10 @@ class Crowdin(object):
             if language_code not in etags:
                 etags[language_code] = {}
 
-            for filepath in self.filepaths():
+            if filepaths is None:
+                filepaths = self.filepaths()
+
+            for filepath in filepaths:
                 etag = etags[language_code].get(filepath, None)
                 response = self.export_file(filepath, language_code, etag=etag)
                 if response.status_code == 200:

--- a/i18n/management/crowdin.py
+++ b/i18n/management/crowdin.py
@@ -9,6 +9,7 @@ import logging
 import requests
 
 from django.utils.translation import to_locale
+from django.core.files.storage import FileSystemStorage
 
 from .utils import get_non_english_language_codes, CHANGES_JSON
 from ..utils import I18nFileWrapper
@@ -201,6 +202,9 @@ class Crowdin(object):
                     )
 
             self.logger.debug("%s files have changes", len(changes[language_code]))
+            storage_etags_path = os.path.join(str(I18nFileWrapper.storage().location), I18nFileWrapper.locale_dir(locale))
+            if isinstance(I18nFileWrapper.storage(), FileSystemStorage) and not os.path.exists(storage_etags_path):
+                os.makedirs(storage_etags_path)
             with I18nFileWrapper.storage().open(etags_path, 'w') as etags_file:
                 json.dump(etags, etags_file, sort_keys=True, indent=4)
 

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -8,6 +8,7 @@ import sys
 from django.conf import settings
 from django.core.cache import cache
 from django.utils.module_loading import import_string
+from django.core.files.storage import FileSystemStorage
 
 logger = logging.getLogger(__name__)
 
@@ -95,4 +96,6 @@ class I18nFileWrapper:
             storage = getattr(settings, 'I18N_STORAGE', 'django.core.files.storage.FileSystemStorage')
             storage_cls = import_string(storage)
             cls._storage = storage_cls(location=getattr(settings, 'I18N_STORAGE_LOCATION', 'i18n'))
+            if isinstance(cls._storage, FileSystemStorage) and not os.path.exists(cls._storage.location):
+                os.makedirs(cls._storage.location)
         return cls._storage


### PR DESCRIPTION
# Description
As discussed offline, we're adding a script that downloads `django.po`  files from Crowdin and compiles them into their respective `django.mo` files. The script is very similar to the [`download_translations`](https://github.com/code-dot-org/curriculumbuilder/blob/master/i18n/management/crowdin.py#L136) function in crowdin.py.

Functionality was tested by: 
1. removing all translations from my local file system, running the `i18n_message_file_sync` command, 
2. verifying that the `django.po` and `.mo` files have been successfully downloaded to the `i18n/static/translations` directory, and
3. verifying that the translated UI element strings show correctly on the local server
Before:
<img width="1045" alt="Screen Shot 2021-02-05 at 4 52 25 PM" src="https://user-images.githubusercontent.com/16494556/107103472-9a08e780-67d2-11eb-889a-62a64424c799.png">
After:
<img width="1058" alt="Screen Shot 2021-02-05 at 4 52 31 PM" src="https://user-images.githubusercontent.com/16494556/107103478-9ecd9b80-67d2-11eb-9c0e-04f136b9cec9.png">

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
