### PR TITLE
upgrade to psycopg2 version 2.8.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ newrelic==2.96.0.80
 oauthlib==1.0.3
 pdfkit==0.5.0
 plotly==1.9.3
-psycopg2==2.8.4
+psycopg2==2.8.6
 pycurl==7.43.0.3
 pyPdf==1.13
 pytz==2015.7


### PR DESCRIPTION
This was the first step for me in fixing a long list of build problems on OS X. Here is everything that i did to get my system working:

1. at some point, brew made me upgrade to openssl@1.1.

2. `pip install -r requirements.txt` broke with:
```
django.core.exceptions.ImproperlyConfigured: Error loading psycopg2 module: dlopen(/Users/dsb/.virtualenvs/cb/lib/python2.7/site-packages/psycopg2/_psycopg.so, 2): Library not loaded: /usr/local/opt/openssl/lib/libssl.1.0.0.dylib
```
I tried installing an older version of openssl, but that didn't work. 

3. I upgraded psycopg2 to the latest version, as shown in this PR. 

4. `pip install -r requirements.txt` now succeeds

5. `debug=true python manage.py runserver_plus` fails with:
```
OperationalError: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
```

6. postgres appeared to not be running:
```
(cb) Dave-MBP:~/src/cb (master *)$ ps -ef | grep postgres
  501 20433 12580   0  6:53AM ttys004    0:00.00 grep postgres
```

7. from https://stackoverflow.com/questions/13410686/postgres-could-not-connect-to-server, I ran:
```
(cb) Dave-MBP:~/src/cb (master *)$ postgres -D /usr/local/var/postgres
2021-02-10 07:02:13.089 PST [21823] FATAL:  database files are incompatible with server
2021-02-10 07:02:13.089 PST [21823] DETAIL:  The data directory was initialized by PostgreSQL version 11, which is not compatible with this version 13.1.
```

8. from https://stackoverflow.com/questions/17822974/postgres-fatal-database-files-are-incompatible-with-server, I ran:
```
brew postgresql-upgrade-database
```

9. `brew services restart postgresql`

10. success!
```
(cb) Dave-MBP:~/src/cb (master *)$ debug=true python manage.py runserver_plus
 * Running on http://127.0.0.1:8000/ (Press CTRL+C to quit)
```