### PR TITLE
adding a link to i18n setup instructions from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ coverage report
 ```
 If you run this often, it may be worth appending the `--keepdb` flag to make it run faster.
 
+### I18n sync
+Follow the [I18n setup instructions](https://github.com/code-dot-org/curriculumbuilder/blob/master/i18n/SETUP.md) to run the sync on your local machine
+
 ### How does the deploy work on CurriculumBuilder
 
 CurriculumBuilder is actually two separate websites:


### PR DESCRIPTION
# Description
Last sprint, I wrote setup instructions for the CB i18n sync. In this PR I'm linking those instructions from the main README to make them more accessible to people trying to set up the repo
<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
