### PR TITLE
Parent Categories are translatable

### DIFF
--- a/standards/models.py
+++ b/standards/models.py
@@ -113,7 +113,7 @@ class Category(Internationalizable):
 
     @property
     def should_be_translated(self):
-        return any(standard.should_be_translated for standard in self.standards.all())
+        return any(standard.should_be_translated for standard in self.child_standards())
 
     @classmethod
     def internationalizable_fields(cls):


### PR DESCRIPTION
# Description
We noticed that Categories which don't directly contain any Standards are not recognized as translatable. This change makes it so if there are any child Categories which contain a Standard, then the Parent Category will be marked for translation.

Example of bug:
![image](https://user-images.githubusercontent.com/1372238/110012137-1f22e600-7d18-11eb-9fd9-6ad3fba17006.png)
Note how **Engineering in the Sciences** is not translatable, but the child Category and Standard are.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1239)

## Testing story
Ran `./managepy gather_i18n_strings` and verified that "Engineering in the Sciences" and a few other Categories are now available in `i18n/static/source/Category.json`. This file contains the Categories which are translatable.

# Reviewer Checklist:

- [x] Tests provide adequate coverage
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
