### PR TITLE
Using the translated string for keywowrds such as Grade levels

### DIFF
--- a/curricula/templates/curricula/partials/hoc_lesson_front.html
+++ b/curricula/templates/curricula/partials/hoc_lesson_front.html
@@ -13,7 +13,7 @@
 
     <div class="keywords">
         <h4>
-            {% for keyword in lesson.keywords.all %}
+            {% for keyword in lesson.translated_keywords %}
                 {% if not forloop.first %}| {% endif %}
                 {{ keyword }}
             {% endfor %}

--- a/curricula/templates/curricula/partials/pl_lesson_front.html
+++ b/curricula/templates/curricula/partials/pl_lesson_front.html
@@ -18,7 +18,7 @@
 
     <div class="keywords">
         <h4>
-            {% for keyword in lesson.keywords.all %}
+            {% for keyword in lesson.translated_keywords %}
                 {% if not forloop.first %}| {% endif %}
                 {{ keyword }}
             {% endfor %}


### PR DESCRIPTION
# Description
Updates the HOC lesson plans on Curriculum Builder to use `translated_keywords` instead of `keywords` so that the translated value of the keyword is displayed to the teacher. Examples for keywords: "Grades 3-5", "Grades6-8", etc.

## Before
![image](https://user-images.githubusercontent.com/1372238/110161692-9bcfc600-7de5-11eb-87a2-520e4f1e15ff.png)


## After
Note that **Grades 3-5** is now outlined which indicates its a translatable field by Crowdin
![image](https://user-images.githubusercontent.com/1372238/110161539-69be6400-7de5-11eb-9b7d-1f8d29c379e8.png)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [JIRA](https://codedotorg.atlassian.net/browse/FND-1405)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
