### PR TITLE
include standards in lesson export

### DIFF
--- a/curricula/serializers.py
+++ b/curricula/serializers.py
@@ -177,12 +177,15 @@ class LessonExportSerializer(serializers.ModelSerializer):
     vocab = serializers.SerializerMethodField()
     blocks = serializers.SerializerMethodField()
     objectives = serializers.SerializerMethodField()
+    standards = serializers.SerializerMethodField()
     stage_name = serializers.SerializerMethodField()
     creative_commons_license = serializers.SerializerMethodField()
 
     class Meta:
         model = Lesson
-        fields = ('title', 'number', 'student_desc', 'teacher_desc', 'activities', 'resources', 'vocab', 'blocks', 'objectives', 'code_studio_url', 'stage_name', 'prep', 'cs_content', 'creative_commons_license', 'assessment')
+        fields = ('title', 'number', 'student_desc', 'teacher_desc', 'activities', 'resources',
+                  'vocab', 'blocks', 'objectives', 'standards', 'code_studio_url', 'stage_name',
+                  'prep', 'cs_content', 'creative_commons_license', 'assessment')
 
     def get_teacher_desc(self, obj):
         return obj.overview
@@ -212,6 +215,11 @@ class LessonExportSerializer(serializers.ModelSerializer):
 
     def get_objectives(self, obj):
         return obj.objective_set.values('name')
+
+    def get_standards(self, obj):
+        standards = obj.standards.all()
+        serializer = StandardSerializer(standards, many=True, context=self.context)
+        return serializer.data
 
     def get_stage_name(self, obj):
         if obj.stage:


### PR DESCRIPTION
Continues on [PLAT-751](https://codedotorg.atlassian.net/browse/PLAT-751). For more background, see [Lesson Standards design doc](https://docs.google.com/document/d/1zvdv7y8VuRz8KqT1rzqeJAmvirCvUr1jS8OWy0p9FHk/edit)

There is an existing way to export lesson-standards relationships, but it has to be run manually for each script via web UI. This PR builds on the existing lesson/unit export functionality instead, which seems better because the existing import_unit_details.rb script is already set up to import this format and also serialize it to script json.
