### PR TITLE
adding trans tags to make UI headers and text translatable

### DIFF
--- a/curricula/templates/curricula/hoc_lesson.html
+++ b/curricula/templates/curricula/hoc_lesson.html
@@ -213,16 +213,16 @@
 
 {% if lesson.standards.count > 0 %}
 <div class="standards">
-    <h2>Standards Alignment</h2>
-    <h4><a href="{{ curriculum.get_standards_url }}">View full course alignment</a></h4>
+    <h2>{% trans "Standards Alignment" %}</h2>
+    <h4><a href="{{ curriculum.get_standards_url }}">{% trans "View full course alignment" %}</a></h4>
     {% include "standards/partials/standard_list.html" with standards=lesson.standards.all %}
 </div>
 {% endif %}
 
 {% if lesson.opportunity_standards.count > 0 %}
 <div class="standards">
-    <h2>Cross-curricular Opportunities</h2>
-    <p>This list represents opportunities in this lesson to support standards in other content areas.</p>
+    <h2>{% trans 'Cross-curricular Opportunities' %}</h2>
+    <p>{% trans "This list represents opportunities in this lesson to support standards in other content areas." %}</p>
     {% include "standards/partials/standard_list.html" with standards=lesson.opportunity_standards.all %}
 </div>
 {% endif %}

--- a/curricula/templates/curricula/partials/lesson.html
+++ b/curricula/templates/curricula/partials/lesson.html
@@ -40,7 +40,7 @@
 
         {% if lesson.standards.count > 0 %}
             <div class="standards">
-                <h2>Standards Alignment</h2>
+                <h2>{% trans "Standards Alignment" %}</h2>
                 {% include "standards/partials/standard_list.html" with standards=lesson.standards.all %}
             </div>
         {% endif %}

--- a/curricula/templates/curricula/partials/pl_lesson.html
+++ b/curricula/templates/curricula/partials/pl_lesson.html
@@ -37,7 +37,7 @@
 
         {% if lesson.standards.count > 0 %}
             <div class="standards">
-                <h2>Standards Alignment</h2>
+                <h2>{% trans "Standards Alignment" %}</h2>
                 {% include "standards/partials/standard_list.html" with standards=lesson.standards.all %}
             </div>
         {% endif %}

--- a/curricula/templates/curricula/partials/pl_lesson.html
+++ b/curricula/templates/curricula/partials/pl_lesson.html
@@ -1,6 +1,7 @@
 {% load mezzanine_tags %}
 {% load keyword_tags %}
 {% load staticfiles %}
+{% load i18n %}
 
 <div class="container">
 

--- a/curricula/templates/curricula/pl_lesson.html
+++ b/curricula/templates/curricula/pl_lesson.html
@@ -127,8 +127,8 @@
 <!-- Standards Alignment -->
 
 <div class="standards">
-    <h2>Standards Alignment</h2>
-    <h4><a href="{{ curriculum.get_standards_url }}">View full course alignment</a></h4>
+    <h2>{% trans "Standards Alignment" %}</h2>
+    <h4><a href="{{ curriculum.get_standards_url }}">{% trans "View full course alignment" %}</a></h4>
     {% include "standards/partials/standard_list.html" with standards=lesson.standards.all %}
 </div>
 {% endcomment %}

--- a/standards/templates/standards/curriculum-supertable.html
+++ b/standards/templates/standards/curriculum-supertable.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 {% load mezzanine_tags %}
 {% load keyword_tags %}
+{% load i18n %}
 
 {% block meta_title %}{{ curriculum.title }} {% trans "Standards Alignment" %}{% endblock %}
 

--- a/standards/templates/standards/curriculum-supertable.html
+++ b/standards/templates/standards/curriculum-supertable.html
@@ -4,7 +4,7 @@
 {% load mezzanine_tags %}
 {% load keyword_tags %}
 
-{% block meta_title %}{{ curriculum.title }} Standards Alignment{% endblock %}
+{% block meta_title %}{{ curriculum.title }} {% trans "Standards Alignment" %}{% endblock %}
 
 {% block meta_keywords %}{% metablock %}
     {% keywords_for page as keywords %}
@@ -27,7 +27,7 @@
 
 {% block header_title %}
     <h1>{{ curriculum.title }}</h1>
-    <span class="disclaimer">Standards Alignment</span>
+    <span class="disclaimer">{% trans "Standards Alignment" %}</span>
 {% endblock %}
 
 {% block main %}

--- a/standards/templates/standards/curriculum-tabulator.html
+++ b/standards/templates/standards/curriculum-tabulator.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 {% load mezzanine_tags %}
 {% load keyword_tags %}
+{% load i18n %}
 
 {% block meta_title %}{{ curriculum.title }} {% trans "Standards Alignment" %}{% endblock %}
 

--- a/standards/templates/standards/curriculum-tabulator.html
+++ b/standards/templates/standards/curriculum-tabulator.html
@@ -4,7 +4,7 @@
 {% load mezzanine_tags %}
 {% load keyword_tags %}
 
-{% block meta_title %}{{ curriculum.title }} Standards Alignment{% endblock %}
+{% block meta_title %}{{ curriculum.title }} {% trans "Standards Alignment" %}{% endblock %}
 
 {% block meta_keywords %}{% metablock %}
     {% keywords_for page as keywords %}
@@ -29,7 +29,7 @@
 
 {% block header_title %}
     <h1>{{ curriculum.title }}</h1>
-    <span class="disclaimer">Standards Alignment</span>
+    <span class="disclaimer">{% trans "Standards Alignment" %}</span>
 {% endblock %}
 
 {% block resources_nav %}

--- a/standards/templates/standards/curriculum.html
+++ b/standards/templates/standards/curriculum.html
@@ -4,7 +4,7 @@
 {% load mezzanine_tags %}
 {% load keyword_tags %}
 
-{% block meta_title %}{{ curriculum.title }} Standards Alignment{% endblock %}
+{% block meta_title %}{{ curriculum.title }} {% trans "Standards Alignment" %}{% endblock %}
 
 {% block meta_keywords %}{% metablock %}
     {% keywords_for page as keywords %}
@@ -29,7 +29,7 @@
 
 {% block header_title %}
     <h1>{{ curriculum.title }}</h1>
-    <span class="disclaimer">Standards Alignment</span>
+    <span class="disclaimer">{% trans "Standards Alignment" %}</span>
 {% endblock %}
 
 {% block resources_nav %}
@@ -63,14 +63,14 @@
 
                 {% if lesson.standards.count > 0 %}
                 <div class="standards">
-                    <h4>Standards Alignment</h4>
+                    <h4>{% trans "Standards Alignment" %}</h4>
                     {% include "standards/partials/standard_list.html" with standards=lesson.standards.all %}
                 </div>
                 {% endif %}
 
                 {% if lesson.opportunity_standards.count > 0 %}
                 <div class="standards">
-                    <h4>Cross-curricular Opportunities</h4>
+                    <h4>{% trans 'Cross-curricular Opportunities' %}</h4>
                     {% include "standards/partials/standard_list.html" with standards=lesson.opportunity_standards.all %}
                 </div>
                 {% endif %}

--- a/standards/templates/standards/curriculum_nogrid.html
+++ b/standards/templates/standards/curriculum_nogrid.html
@@ -5,7 +5,7 @@
 {% load keyword_tags %}
 {% load i18n %}
 
-{% block meta_title %}{{ curriculum.title }} Standards Alignment{% endblock %}
+{% block meta_title %}{{ curriculum.title }} {% trans "Standards Alignment" %}{% endblock %}
 
 {% block meta_keywords %}{% metablock %}
     {% keywords_for page as keywords %}
@@ -25,7 +25,7 @@
 
 {% block header_title %}
     <h1>{{ curriculum.title }}</h1>
-    <h2 class="disclaimer">Standards Alignment</h2>
+    <h2 class="disclaimer">{% trans "Standards Alignment" %}</h2>
 {% endblock %}
 
 {% block resources_nav %}
@@ -63,7 +63,7 @@
       <div>
         <h2>How should I use this information?</h2>
         <p>
-          <span style="font-weight:900;">CSTA Standards Alignment</span>: Code.org’s CS Fundamentals course is aligned with the Computer Science Teachers’ Association (CSTA) standards for K-5 students. You can hit these standards by following our lesson plans. You can also see what CSTA standards your class has worked on in the Standards view of the teacher dashboard. <a href="https://support.code.org/hc/en-us/articles/360041726272-Can-I-see-my-class-s-progress-on-CSTA-Standards-Is-there-an-easy-progress-report-I-can-send-out-for-my-class-">Learn more.</a>
+          <span style="font-weight:900;">CSTA {% trans "Standards Alignment" %}</span>: Code.org’s CS Fundamentals course is aligned with the Computer Science Teachers’ Association (CSTA) standards for K-5 students. You can hit these standards by following our lesson plans. You can also see what CSTA standards your class has worked on in the Standards view of the teacher dashboard. <a href="https://support.code.org/hc/en-us/articles/360041726272-Can-I-see-my-class-s-progress-on-CSTA-Standards-Is-there-an-easy-progress-report-I-can-send-out-for-my-class-">Learn more.</a>
         </p>
         <a class="btn" role="button" style="font-size: 16px; padding-left: 0px;" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
             <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download standards mapping as CSV' %}
@@ -74,7 +74,7 @@
         <a href="https://docs.google.com/document/d/e/2PACX-1vRxKtK0HZ4jlqDG0kf5J8l0p_wTGZRQCwBY8HupNVl2EiPC7qs-57Ct0zMyLxuGEuWJX3lF9QbsDUNY/pub">
           Cross-Curricular Standards Guidance
         </a>
-        <h2>Standards Alignment</h2>
+        <h2>{% trans "Standards Alignment" %}</h2>
       </div>
     {% endif %}
     <div class="together standards row" style="margin-left: 0px;">

--- a/standards/templates/standards/curriculum_nogrid.html
+++ b/standards/templates/standards/curriculum_nogrid.html
@@ -61,7 +61,7 @@
     </div>
     {% if curriculum.has_cross_curricular_info %}
       <div>
-        <h2>How should I use this information?</h2>
+        <h2>{% trans "How should I use this information?" %}</h2>
         <p>
           <span style="font-weight:900;">{% trans "CSTA Standards Alignment" %}</span>: {%trans "Code.org’s CS Fundamentals course is aligned with the Computer Science Teachers’ Association (CSTA) standards for K-5 students. You can hit these standards by following our lesson plans. You can also see what CSTA standards your class has worked on in the Standards view of the teacher dashboard." %}<a href="https://support.code.org/hc/en-us/articles/360041726272-Can-I-see-my-class-s-progress-on-CSTA-Standards-Is-there-an-easy-progress-report-I-can-send-out-for-my-class-">{% trans "Learn more." %}</a>
         </p>
@@ -69,10 +69,10 @@
             <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download standards mapping as CSV' %}
         </a>
         <p>
-          <span style="font-weight:900;">{% trans "Cross-Curricular Standards" %}</span>: Computer science helps students with problem-solving, logical thinking, cause and effect, and computational thinking. CS Fundamentals also includes opportunities for teachers to reinforce concepts related to English language arts, mathematics, and science while students are learning computer science. You can help students practice these standards just by following our lesson plans or by making slight adaptations, as outlined in our Cross-Curricular Standards Guidance below.
+          <span style="font-weight:900;">{% trans "Cross-Curricular Standards" %}</span>: {%trans "Computer science helps students with problem-solving, logical thinking, cause and effect, and computational thinking. CS Fundamentals also includes opportunities for teachers to reinforce concepts related to English language arts, mathematics, and science while students are learning computer science. You can help students practice these standards just by following our lesson plans or by making slight adaptations, as outlined in our Cross-Curricular Standards Guidance below." %}
         </p>
         <a href="https://docs.google.com/document/d/e/2PACX-1vRxKtK0HZ4jlqDG0kf5J8l0p_wTGZRQCwBY8HupNVl2EiPC7qs-57Ct0zMyLxuGEuWJX3lF9QbsDUNY/pub">
-          Cross-Curricular Standards Guidance
+            {% trans "Cross-Curricular Standards Guidance" %}
         </a>
         <h2>{% trans "Standards Alignment" %}</h2>
       </div>

--- a/standards/templates/standards/curriculum_nogrid.html
+++ b/standards/templates/standards/curriculum_nogrid.html
@@ -63,13 +63,13 @@
       <div>
         <h2>How should I use this information?</h2>
         <p>
-          <span style="font-weight:900;">CSTA {% trans "Standards Alignment" %}</span>: Code.org’s CS Fundamentals course is aligned with the Computer Science Teachers’ Association (CSTA) standards for K-5 students. You can hit these standards by following our lesson plans. You can also see what CSTA standards your class has worked on in the Standards view of the teacher dashboard. <a href="https://support.code.org/hc/en-us/articles/360041726272-Can-I-see-my-class-s-progress-on-CSTA-Standards-Is-there-an-easy-progress-report-I-can-send-out-for-my-class-">Learn more.</a>
+          <span style="font-weight:900;">{% trans "CSTA Standards Alignment" %}</span>: {%trans "Code.org’s CS Fundamentals course is aligned with the Computer Science Teachers’ Association (CSTA) standards for K-5 students. You can hit these standards by following our lesson plans. You can also see what CSTA standards your class has worked on in the Standards view of the teacher dashboard." %}<a href="https://support.code.org/hc/en-us/articles/360041726272-Can-I-see-my-class-s-progress-on-CSTA-Standards-Is-there-an-easy-progress-report-I-can-send-out-for-my-class-">{% trans "Learn more." %}</a>
         </p>
         <a class="btn" role="button" style="font-size: 16px; padding-left: 0px;" href="{% url 'curriculum:by_curriculum_csv' curriculum.slug %}">
             <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> {% trans 'Download standards mapping as CSV' %}
         </a>
         <p>
-          <span style="font-weight:900;">Cross-Curricular Standards</span>: Computer science helps students with problem-solving, logical thinking, cause and effect, and computational thinking. CS Fundamentals also includes opportunities for teachers to reinforce concepts related to English language arts, mathematics, and science while students are learning computer science. You can help students practice these standards just by following our lesson plans or by making slight adaptations, as outlined in our Cross-Curricular Standards Guidance below.
+          <span style="font-weight:900;">{% trans "Cross-Curricular Standards" %}</span>: Computer science helps students with problem-solving, logical thinking, cause and effect, and computational thinking. CS Fundamentals also includes opportunities for teachers to reinforce concepts related to English language arts, mathematics, and science while students are learning computer science. You can help students practice these standards just by following our lesson plans or by making slight adaptations, as outlined in our Cross-Curricular Standards Guidance below.
         </p>
         <a href="https://docs.google.com/document/d/e/2PACX-1vRxKtK0HZ4jlqDG0kf5J8l0p_wTGZRQCwBY8HupNVl2EiPC7qs-57Ct0zMyLxuGEuWJX3lF9QbsDUNY/pub">
           Cross-Curricular Standards Guidance

--- a/standards/templates/standards/framework.html
+++ b/standards/templates/standards/framework.html
@@ -4,7 +4,7 @@
 {% load mezzanine_tags %}
 {% load keyword_tags %}
 
-{% block meta_title %}{{ framework.name }} Standards Alignment{% endblock %}
+{% block meta_title %}{{ framework.name }} {% trans "Standards Alignment" %}{% endblock %}
 
 {% block meta_keywords %}{% metablock %}
     {% keywords_for page as keywords %}

--- a/standards/templates/standards/framework.html
+++ b/standards/templates/standards/framework.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 {% load mezzanine_tags %}
 {% load keyword_tags %}
+{% load i18n %}
 
 {% block meta_title %}{{ framework.name }} {% trans "Standards Alignment" %}{% endblock %}
 

--- a/standards/templates/standards/index.html
+++ b/standards/templates/standards/index.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 {% load mezzanine_tags %}
 {% load keyword_tags %}
+{% load i18n %}
 
 {% block meta_title %}{% trans "Standards Alignment" %}{% endblock %}
 

--- a/standards/templates/standards/index.html
+++ b/standards/templates/standards/index.html
@@ -4,7 +4,7 @@
 {% load mezzanine_tags %}
 {% load keyword_tags %}
 
-{% block meta_title %}Standards Alignment{% endblock %}
+{% block meta_title %}{% trans "Standards Alignment" %}{% endblock %}
 
 {% block meta_keywords %}{% metablock %}
     {% keywords_for page as keywords %}
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block header_title %}
-    <h1>Standards Alignment</h1>
+    <h1>{% trans "Standards Alignment" %}</h1>
 {% endblock %}
 
 {% block main %}

--- a/standards/templates/standards/standard.html
+++ b/standards/templates/standards/standard.html
@@ -4,7 +4,7 @@
 {% load mezzanine_tags %}
 {% load keyword_tags %}
 
-{% block meta_title %}{{ standard.framework.name }} Standards Alignment{% endblock %}
+{% block meta_title %}{{ standard.framework.name }} {% trans "Standards Alignment" %}{% endblock %}
 
 {% block meta_description %}{% metablock %}
     {{ framework.description }}

--- a/standards/templates/standards/standard.html
+++ b/standards/templates/standards/standard.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 {% load mezzanine_tags %}
 {% load keyword_tags %}
+{% load i18n %}
 
 {% block meta_title %}{{ standard.framework.name }} {% trans "Standards Alignment" %}{% endblock %}
 

--- a/templates/pages/lesson.html
+++ b/templates/pages/lesson.html
@@ -124,7 +124,7 @@
     </div>
 
     <div id="standards">
-        <h2>Standards Alignment</h2>
+        <h2>{% trans "Standards Alignment" %}</h2>
         {% with standards=page.lesson.standards.all %}
         {% regroup standards by framework as standards_by_framework %}
         {% for framework in standards_by_framework %}

--- a/templates/pages/lesson.html
+++ b/templates/pages/lesson.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 {% load mezzanine_tags %}
 {% load keyword_tags %}
+{% load i18n %}
 
 {% block meta_title %}{{ page.meta_title }}{% endblock %}
 


### PR DESCRIPTION
# Description
Some shared header text in the lesson plans ("Standards Alignment", "Cross-curricular Opportunities", and more) have translations available, but are not using the `trans` tag to correctly display the translations. This PR adds those tags so that the translated strings display instead of English.
<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
[jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&modal=detail&selectedIssue=FND-1462)
<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
