### PR TITLE
Add translated keyword strings

### DIFF
--- a/curricula/templates/curricula/unit.html
+++ b/curricula/templates/curricula/unit.html
@@ -121,7 +121,7 @@
                               </a>
                             </h3>
                             <h4>
-                            {% for keyword in keywords %}
+                            {% for keyword in lesson.translated_keywords %}
                                 {% if not forloop.first %}| {% endif %}
                                 {{ keyword }}
                             {% endfor %}
@@ -137,14 +137,16 @@
                             {% if lesson.resources.count > 0 %}
                                 <h4>
                                     {% with lesson.resources.all as resources %}
+                                    {% with _('Students Links:')|add:','|add:_('Teacher Links:') as groups %}
                                         {% regroup resources|dictsort:"student" by student as resources_by_audience %}
                                         {% for audience in resources_by_audience %}
-                                            {{ audience.grouper|yesno:"Student,Teacher" }} Links:
+                                            {{ audience.grouper|yesno:groups }}
                                                 {% for resource in audience.list %}
                                                     {% if not forloop.first %} | {% endif %}
                                                     <a href="{{ resource.url }}" target="_blank">{{ resource.type }}</a>
                                                 {% endfor %}
                                         {% endfor %}
+                                    {% endwith %}
                                     {% endwith %}
                                 </h4>
                             {% endif %}
@@ -170,15 +172,17 @@
                                     <span class="lesson_desc">{{ optional.description|richtext_filters|safe }}</span>
                                     {% if lesson.resources.count > 0 %}
                                         <h4>
-                                            {% with optional.resources.all as resources %}
+                                            {% with lesson.resources.all as resources %}
+                                            {% with _('Students Links:')|add:','|add:_('Teacher Links:') as groups %}
                                                 {% regroup resources|dictsort:"student" by student as resources_by_audience %}
                                                 {% for audience in resources_by_audience %}
-                                                    {{ audience.grouper|yesno:"Student,Teacher" }} Links:
+                                                    {{ audience.grouper|yesno:groups }}
                                                         {% for resource in audience.list %}
                                                             {% if not forloop.first %} | {% endif %}
                                                             <a href="{{ resource.url }}" target="_blank">{{ resource.type }}</a>
                                                         {% endfor %}
                                                 {% endfor %}
+                                            {% endwith %}
                                             {% endwith %}
                                         </h4>
                                     {% endif %}

--- a/curricula/templates/curricula/unit.html
+++ b/curricula/templates/curricula/unit.html
@@ -267,15 +267,17 @@
                                     <span class="lesson_desc">{{ optional.description|richtext_filters|safe }}</span>
                                     {% if lesson.resources.count > 0 %}
                                         <h4>
-                                            {% with optional.resources.all as resources %}
+                                            {% with lesson.resources.all as resources %}
+                                            {% with _('Students Links:')|add:','|add:_('Teacher Links:') as groups %}
                                                 {% regroup resources|dictsort:"student" by student as resources_by_audience %}
                                                 {% for audience in resources_by_audience %}
-                                                    {{ audience.grouper|yesno:"Student,Teacher" }} Links:
+                                                    {{ audience.grouper|yesno:groups }}
                                                         {% for resource in audience.list %}
                                                             {% if not forloop.first %} | {% endif %}
                                                             <a href="{{ resource.url }}" target="_blank">{{ resource.type }}</a>
                                                         {% endfor %}
                                                 {% endfor %}
+                                            {% endwith %}
                                             {% endwith %}
                                         </h4>
                                     {% endif %}

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -414,6 +414,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Filterable):
         if lang and lang != settings.LANGUAGE_CODE:
             locale = translation.to_locale(lang)
             return [I18nFileWrapper.get_translated_field('I18nKeyword', slugify(keyword), 'title', locale) or keyword for keyword in self.keywords.all()]
+        return self.keywords.all()
 
     def can_access(self, request):
         return request.user.has_perm('lessons.access_all_lessons') or request.user.id == self.user_id

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -409,6 +409,8 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Filterable):
     def __unicode__(self):
         return self.title
 
+    # returns list of translated keywords if language is non-English.
+    # Falls back to the existing keywords list otherwise
     def translated_keywords(self):
         lang = translation.get_language()
         if lang and lang != settings.LANGUAGE_CODE:


### PR DESCRIPTION
# Description
Prior to this change, the translated_keywords function only returned keywords if the language was non-English, causing English pages to show no keywords on some pages. This PR adds a fallback to return English keywords if the language is English. 

Additionally, this PR makes "Students Links" and "Teacher Links" translatable in code paths where it was previously missed.
<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&modal=detail&selectedIssue=FND-1466)

## Testing story
Manually tested on localhost

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
