### PR TITLE
Fnd 1401 add notification on i18n failure

### DIFF
--- a/i18n/management/commands/log_i18n_failure.py
+++ b/i18n/management/commands/log_i18n_failure.py
@@ -9,4 +9,4 @@ class Command(BaseCommand):
     See bin/sync_i18n.sh for context.
     """
     def handle(self, *args, **options):
-        log("ERROR: I18n Sync encountered a problem and did not complete")
+        log("<!subteam^S017CFFHHT9|foundations-team> ERROR: I18n Sync encountered a problem and did not complete")

--- a/templates/slack/message.slack
+++ b/templates/slack/message.slack
@@ -3,5 +3,7 @@
 {% load django_slack %}
 
 {% block text %}
+{% autoescape off %}
 {{ user.get_username|escapeslack }} {% if message %}{{ message }}{% else %}did a thing{% endif %}
+{% endautoescape %}
 {% endblock %}


### PR DESCRIPTION
# Description
Updates the CurriculumBuilder i18n sync to ping @foundations-team when the i18n sync fails. This will be useful because we often don't notice when this system is broken.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1401)

## Testing story
Manually tested and successfully notified the slack group.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
