### PR TITLE
Upgrade stack to Heroku 18

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: python manage.py migrate --noinput
-web: bin/start-nginx bin/start-pgbouncer-stunnel newrelic-admin run-program python run.py
+web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program python run.py

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "curriculumbuilder",
-  "scripts": {
-  },
+  "scripts": {},
+  "stack": "heroku-18",
   "env": {
     "AUTO_PUBLISH": {
       "required": true

--- a/app.json
+++ b/app.json
@@ -93,7 +93,7 @@
   ],
   "buildpacks": [
     {
-      "url": "https://github.com/mrjoshida/nginx-buildpack"
+      "url": "https://github.com/heroku/heroku-buildpack-nginx.git"
     },
     {
       "url": "https://github.com/heroku/heroku-buildpack-pgbouncer"

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -42,11 +42,8 @@ http {
 			proxy_pass http://app_server;
 		}
 
-        location ^~ /test {
-			default_type 'text/plain';
-			content_by_lua_block {
-				ngx.say('I am still listening...')
-			}
-        }
+    location ^~ /test {
+      default_type 'text/plain';
+    }
 	}
 }

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -9,9 +9,9 @@ events {
 }
 
 http {
-        gzip on;
-        gzip_comp_level 2;
-        gzip_min_length 512;
+	gzip on;
+	gzip_comp_level 2;
+	gzip_min_length 512;
 
 	server_tokens off;
 
@@ -28,7 +28,7 @@ http {
 
 	upstream app_server {
 		server unix:/tmp/nginx.socket fail_timeout=0;
- 	}
+	}
 
 	server {
 		listen <%= ENV["PORT"] %>;
@@ -42,8 +42,8 @@ http {
 			proxy_pass http://app_server;
 		}
 
-    location ^~ /test {
-      default_type 'text/plain';
-    }
+		location ^~ /test {
+			default_type 'text/plain';
+		}
 	}
 }


### PR DESCRIPTION
Turns out, we didn't have to do much at all to get Heroku 18 to work!

- Heroku has deprecated `bin/start-pgbouncer-stunnel`in favor of `bin/start-pgbouncer`. In fact, the former is now [just an alias to the latter](https://github.com/heroku/heroku-buildpack-pgbouncer/blob/b229604a206c4d350405496f97e2175e8b7caf70/bin/start-pgbouncer-stunnel#L3-L6) so we can safely switch this without needing to do any follow-up work
- We were formerly on a custom branch of the nginx buildpack, which has not been updated to support modern infrastructure. Switch back to the mainline branch instead. It's not at all clear to me why we were on that custom branch, but I haven't been able to find any issues with the mainline branch through manual testing.
- The nginx directive `content_by_lua_block` requires an nginx module to be initialized in the environment which seems to be missing in Heroku 18. I invested some time in trying to figure out how to get that module back in, but couldn't make it work; fortunately, I also couldn't find anything to indicate that we're actually using this functionality anywhere, so I simply took it out.

All in all, less work than I expected, and _much_ less than I feared!

## Heroku 20?

One note: this upgrade to Heroku 18 buys us two more years of being able to use this service; it will only be supported through April 2023. Heroku-20 is also out and is the current recommended version, but unfortunately it does not support Python 2.7. Our current plan is to be off Curriculumbuilder entirely before Heroku 18 gets end-of-life'd, but I want to make sure to call out that if deprecating this project ends up getting delayed, we will need to upgrade not only Python but I believe also Django in order to move on to Heroku 20 and beyond.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
