### PR TITLE
update urls to use lessons and levels instead of stage and puzzle

### DIFF
--- a/curricula/tests/test_curricula_rendering.py
+++ b/curricula/tests/test_curricula_rendering.py
@@ -151,11 +151,11 @@ class CurriculaRenderingTestCase(TestCase):
     def test_render_lesson_with_levels(self):
         stage = {
             "levels": [{
-                "path": "/s/dance/stage/1/puzzle/1",
+                "path": "/s/dance/lessons/1/levels/1",
                 "name": "Dance_Party_11",
                 "mini_rubric": True
             },{
-                "path": "/s/dance/stage/1/puzzle/2",
+                "path": "/s/dance/lessons/1/levels/2",
                 "name": "Dance_Party_22",
                 "teacher_markdown": "teacher markdown",
                 "named_level": True
@@ -176,7 +176,7 @@ class CurriculaRenderingTestCase(TestCase):
                 "bonus_level": False,
                 "assessment": "",
                 "progression": "",
-                "path": "/s/dance/stage/1/puzzle/1",
+                "path": "/s/dance/lessons/1/levels/1",
                 "name": "Dance_Party_11",
                 "display_name": "Bubble Choice: All the Choices",
                 "description": "This is a BubbleChoice level. Choose one of the activities below to practice what you have learned!",

--- a/lessons/models.py
+++ b/lessons/models.py
@@ -563,7 +563,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Filterable):
             return {'error': 'No unit name for unit', 'status': 404}
         else:
             try:
-                url = "https://levelbuilder-studio.code.org/s/%s/stage/%d/summary_for_lesson_plans" % (
+                url = "https://levelbuilder-studio.code.org/s/%s/lessons/%d/summary_for_lesson_plans" % (
                     self.unit.unit_name, self.number)
                 response = urllib2.urlopen(url)
                 data = json.loads(response.read())
@@ -626,7 +626,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Filterable):
         '''
         # Don't try to get stage data on every save.
         try:
-            url = "https://levelbuilder-studio.code.org/s/%s/stage/%d/summary_for_lesson_plans" % (
+            url = "https://levelbuilder-studio.code.org/s/%s/lessons/%d/summary_for_lesson_plans" % (
             self.unit.unit_name, self.number)
             response = urllib2.urlopen(url)
             data = json.loads(response.read())
@@ -717,7 +717,7 @@ class Lesson(InternationalizablePage, RichText, CloneableMixin, Filterable):
 
     @property
     def code_studio_link(self):
-        return self.code_studio_url or "https://studio.code.org/s/%s/stage/%d/puzzle/1/" % (
+        return self.code_studio_url or "https://studio.code.org/s/%s/lessons/%d/levels/1/" % (
             self.unit.unit_name, self.number)
 
     @property


### PR DESCRIPTION
The URL update we made on Code Studio( https://github.com/code-dot-org/code-dot-org/pull/38802) from /stage to /lessons broke the code studio pull through (https://codedotorg.slack.com/archives/CNZP84FJ5/p1619128208169200) . This updates that path as well as a couple other things that were pointing to /stage or /puzzle.