### PR TITLE
Revert "Java updates for Heroku 18"

### DIFF
--- a/app.json
+++ b/app.json
@@ -109,9 +109,6 @@
     },
     {
       "url": "https://github.com/piotras/heroku-buildpack-gettext"
-    },
-    {
-      "url": "heroku/jvm"
     }
   ]
 }

--- a/i18n/SETUP.md
+++ b/i18n/SETUP.md
@@ -43,5 +43,10 @@ If you want to test uploading strings to S3, set the `AWS_STORAGE_BUCKET_NAME` t
 Additionally delete the `I18N_STORAGE` configuration in your `local_settings.py` so that the sync uses S3 for storage.
 
 ### Troubleshooting
+####.apt//usr/lib/jvm/java-8-openjdk-amd64/bin/java: No such file or directory
 
-Make sure you have Crowdin version [2.x](https://downloads.crowdin.com/cli/v2/crowdin-cli.zip) installed on your local machine. Follow [Crowdin's setup instructions](https://github.com/crowdin/crowdin-cli/tree/v2.0.31) to correctly install.
+If you see the above error while running the `i18n_sync_up`, update the contents of `heroku_crowdin.sh` to 
+```
+crowdin "$@"
+```
+Additionally, make sure you have Crowdin version [2.x](https://downloads.crowdin.com/cli/v2/crowdin-cli.zip) installed on your local machine. Follow [Crowdin's setup instructions](https://github.com/crowdin/crowdin-cli/tree/v2.0.31) to correctly install.

--- a/i18n/heroku_crowdin.sh
+++ b/i18n/heroku_crowdin.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script exists solely to run heroku on crowdin. It's necessary for three
+# reasons:
+#
+# First, the heroku apt buildpack doesn't correctly add the installed crowdin
+# binary to the path (see https://github.com/heroku/heroku-buildpack-apt/pull/10)
+#
+# Second, the heroku apt buildpack also doesn't add the java executable to the
+# path. This might be because the default-jre package expects
+# update-alternatives to set up the symlinks, but the actual cause is unclear.
+#
+# Third, the heroku scheduler sets $JAVA_TOOL_OPTIONS to some value that causes
+# this manual invocation of java to break (an environment state that is not
+# replicated when running scripts with `heroku run`), so we need to make sure
+# it's unset for this invocation.
+#
+# Either way, this script exists solely to get around that, and if we are ever
+# able to come up with a clean way to install the crowdin-cli and its
+# dependencies on heroku this can be removed.
+
+apt_dir="${BASH_SOURCE%/*}/../.apt/"
+JAVA_TOOL_OPTIONS= $apt_dir/usr/lib/jvm/java-8-openjdk-amd64/bin/java -jar "$apt_dir/usr/lib/crowdin/crowdin-cli.jar" "$@"

--- a/i18n/heroku_crowdin.sh
+++ b/i18n/heroku_crowdin.sh
@@ -11,4 +11,4 @@
 # binary to the path (see https://github.com/heroku/heroku-buildpack-apt/pull/10)
 
 apt_lib_dir="/app/.apt/usr/lib"
-$apt_lib_dir/jvm/java-8-openjdk-amd64/bin/java -jar "$apt_lib_dir/crowdin/crowdin-cli.jar" "$@"
+$apt_lib_dir/jvm/java-11-openjdk-amd64/bin/java -jar "$apt_lib_dir/crowdin/crowdin-cli.jar" "$@"

--- a/i18n/heroku_crowdin.sh
+++ b/i18n/heroku_crowdin.sh
@@ -1,23 +1,14 @@
 #!/bin/bash
 
-# This script exists solely to run heroku on crowdin. It's necessary for three
+# This script exists solely to run heroku on crowdin. It's necessary for two
 # reasons:
 #
-# First, the heroku apt buildpack doesn't correctly add the installed crowdin
+# First, java is not available in the heroku path. It could be if we added the
+# Heroku JVM buildpack, but unfortunately doing so puts us over the 500mb slug
+# limit.
+#
+# Second, the heroku apt buildpack doesn't correctly add the installed crowdin
 # binary to the path (see https://github.com/heroku/heroku-buildpack-apt/pull/10)
-#
-# Second, the heroku apt buildpack also doesn't add the java executable to the
-# path. This might be because the default-jre package expects
-# update-alternatives to set up the symlinks, but the actual cause is unclear.
-#
-# Third, the heroku scheduler sets $JAVA_TOOL_OPTIONS to some value that causes
-# this manual invocation of java to break (an environment state that is not
-# replicated when running scripts with `heroku run`), so we need to make sure
-# it's unset for this invocation.
-#
-# Either way, this script exists solely to get around that, and if we are ever
-# able to come up with a clean way to install the crowdin-cli and its
-# dependencies on heroku this can be removed.
 
-apt_dir="${BASH_SOURCE%/*}/../.apt/"
-JAVA_TOOL_OPTIONS= $apt_dir/usr/lib/jvm/java-8-openjdk-amd64/bin/java -jar "$apt_dir/usr/lib/crowdin/crowdin-cli.jar" "$@"
+apt_lib_dir="/app/.apt/usr/lib"
+$apt_lib_dir/jvm/java-8-openjdk-amd64/bin/java -jar "$apt_lib_dir/crowdin/crowdin-cli.jar" "$@"

--- a/i18n/management/commands/i18n_sync_up.py
+++ b/i18n/management/commands/i18n_sync_up.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         """Upload sources files to crowdin"""
         log("Uploading source files")
         subprocess.call([
-            "crowdin",
+            os.path.join(I18nFileWrapper.i18n_dir(), 'heroku_crowdin.sh'),
             "--config", os.path.join(I18nFileWrapper.i18n_dir(), "config", "crowdin.yml"),
             "upload sources"
         ])


### PR DESCRIPTION
Reverts code-dot-org/curriculumbuilder#359

All the great effects of that PR were conditional on us adding the `heroku/jvm` buildpack so we could get hack-free Java functionality. Unfortunately, it turns out heroku has a hard limit on slug size, which includes the size of all included buildpacks, and adding this buildpack put us over the limit. I poked around a bit looking for other things we could cut to reduce size, but unfortunately couldn't find anything. So it's back to the hack. :(