### PR TITLE
safely check whether any units have cross curricular info

### DIFF
--- a/curricula/models.py
+++ b/curricula/models.py
@@ -263,7 +263,8 @@ class Curriculum(InternationalizablePage, RichText, CloneableMixin, Ownable):
 
     @property
     def has_cross_curricular_info(self):
-        return Unit.objects.filter(parent=self, login_required=False)[0].has_cross_curricular_info
+        units = Unit.objects.filter(parent=self, login_required=False)
+        return any(unit.has_cross_curricular_info for unit in units)
 
     @property
     def should_be_translated(self):


### PR DESCRIPTION
## Description

publishing broken after all the units in codecurricla.com/plcsd-21 were hidden. publishing broke because publishing plcsd-21 depends on loading /plcsd-21/standards, which broke because of https://github.com/code-dot-org/curriculumbuilder/blob/09018bd2211d68ac8eb9b850899d0fad9b257426/curricula/models.py#L265-L266

The solution is to safely check whether any units have cross curricular info, even if they are all hidden.

## Testing

I was able to repro the original problem locally. after the fix, I verified the following locally:
* I can now load http://localhost:8000/plcsd-21/standards
* I can still load http://localhost:8000/plcsd-20/standards, and it looks the same as codecurricula.com/plcsd-20/standards