### PR TITLE
lock to java 8

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,3 +1,3 @@
 python-cairo
 https://artifacts.crowdin.com/repo/deb/crowdin.deb
-default-jre
+openjdk-8-jre

--- a/i18n/heroku_crowdin.sh
+++ b/i18n/heroku_crowdin.sh
@@ -11,4 +11,4 @@
 # binary to the path (see https://github.com/heroku/heroku-buildpack-apt/pull/10)
 
 apt_lib_dir="/app/.apt/usr/lib"
-$apt_lib_dir/jvm/java-11-openjdk-amd64/bin/java -jar "$apt_lib_dir/crowdin/crowdin-cli.jar" "$@"
+$apt_lib_dir/jvm/java-8-openjdk-amd64/bin/java -jar "$apt_lib_dir/crowdin/crowdin-cli.jar" "$@"


### PR DESCRIPTION
# Description

Okay, this one was an adventure. So, when we upgraded our heroku stack to Heroku-18, one of the changes was that the version of Java installed on our dynos changed from 8 to 11. This broke the hack we were using to get the Crowdin CLI to execute, and (after an unsuccessful detour trying to replace the hack with a real implementation) so we had to manually update the hack to java 11. Unfortunately, after doing so we started getting this error:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
        at java.base/javax.crypto.Cipher.getInstance(Cipher.java:540)
        at java.base/sun.security.ssl.JsseJce.getCipher(JsseJce.java:185)
        at java.base/sun.security.ssl.SSLCipher.isTransformationAvailable(SSLCipher.java:483)
        at java.base/sun.security.ssl.SSLCipher.<init>(SSLCipher.java:472)
        at java.base/sun.security.ssl.SSLCipher.<clinit>(SSLCipher.java:81)
        at java.base/sun.security.ssl.CipherSuite.<clinit>(CipherSuite.java:67)
        at java.base/sun.security.ssl.SSLContextImpl.getApplicableSupportedCipherSuites(SSLContextImpl.java:348)
        at java.base/sun.security.ssl.SSLContextImpl$AbstractTLSContext.<clinit>(SSLContextImpl.java:580)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:315)
        at java.base/java.security.Provider$Service.getImplClass(Provider.java:1918)
        at java.base/java.security.Provider$Service.newInstance(Provider.java:1894)
        at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:236)
        at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:164)
        at java.base/javax.net.ssl.SSLContext.getInstance(SSLContext.java:168)
        at java.base/javax.net.ssl.SSLContext.getDefault(SSLContext.java:99)
        at java.base/javax.net.ssl.SSLSocketFactory.getDefault(SSLSocketFactory.java:123)
        at java.base/javax.net.ssl.HttpsURLConnection.getDefaultSSLSocketFactory(HttpsURLConnection.java:335)
        at java.base/javax.net.ssl.HttpsURLConnection.<init>(HttpsURLConnection.java:292)
        at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.<init>(HttpsURLConnectionImpl.java:100)
        at java.base/sun.net.www.protocol.https.Handler.openConnection(Handler.java:62)
        at java.base/sun.net.www.protocol.https.Handler.openConnection(Handler.java:57)
        at java.base/java.net.URL.openConnection(URL.java:1099)
        at com.crowdin.utils.ConnectionFactory.getHttpURLConnection(ConnectionFactory.java:34)
        at com.sun.jersey.client.urlconnection.URLConnectionClientHandler._invoke(URLConnectionClientHandler.java:165)
        at com.sun.jersey.client.urlconnection.URLConnectionClientHandler.handle(URLConnectionClientHandler.java:153)
        at com.sun.jersey.api.client.Client.handle(Client.java:652)
        at com.sun.jersey.api.client.WebResource.handle(WebResource.java:682)
        at com.sun.jersey.api.client.WebResource.access$200(WebResource.java:74)
        at com.sun.jersey.api.client.WebResource$Builder.get(WebResource.java:509)
        at com.crowdin.utils.HttpRequest.get(HttpRequest.java:76)
        at com.crowdin.client.CrowdinApiClientImpl.proccesing(CrowdinApiClientImpl.java:345)
        at com.crowdin.client.CrowdinApiClientImpl.init(CrowdinApiClientImpl.java:248)
        at com.crowdin.cli.commands.Commands.initCli(Commands.java:884)
        at com.crowdin.cli.commands.Commands.initialize(Commands.java:130)
        at com.crowdin.cli.commands.Commands.run(Commands.java:245)
        at com.crowdin.cli.Cli.main(Cli.java:21)
Caused by: java.lang.SecurityException: Can not initialize cryptographic mechanism
        at java.base/javax.crypto.JceSecurity.<clinit>(JceSecurity.java:120)
        ... 37 more
Caused by: java.lang.SecurityException: Couldn't parse jurisdiction policy files in: unlimited
        at java.base/javax.crypto.JceSecurity.setupJurisdictionPolicies(JceSecurity.java:357)
        at java.base/javax.crypto.JceSecurity$1.run(JceSecurity.java:111)
        at java.base/javax.crypto.JceSecurity$1.run(JceSecurity.java:108)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.base/javax.crypto.JceSecurity.<clinit>(JceSecurity.java:107)
        ... 37 more
```

It's still not entirely clear to me what the problem is here, but some searching around did reveal that Java 9 introduced some relevant changes here. I attempted several different approaches to coax java 11 back into working for us, but no dice. Until, finally, I realized that this java installation wasn't coming from Heroku itself, but from the `default-jre` package that we ask it to install for us. And what changed with the new stack is simply the version of Java that package points to.

So, after all that, we arrive here: replace that package in our Aptfile with a version-specific one locked to the last known working version, and revert the hack back to the same.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
