### PR TITLE
add a new path to export hoc lesson details to code studio

### DIFF
--- a/curricula/urls.py
+++ b/curricula/urls.py
@@ -83,6 +83,9 @@ urlpatterns = patterns('curricula.views',
                        url(r'^(?P<slug>[-\w]+)/(?P<unit_slug>[-\w]+)/(?P<lesson_num>\d+)/overview/$',
                            views.lesson_overview, name='lesson_overview'),
 
+                       # Export this lesson for import into code studio
+                       url(r'^(?P<slug>[-\w]+)/(?P<unit_slug>[-\w]+)/(?P<lesson_num>\d+).json$', views.lesson_export, name="lesson_export"),
+
                        # Option Lessons (I hates them)
                        url(r'^(?P<slug>[-\w]+)/(?P<unit_slug>[-\w]+)/(?P<lesson_num>\d+)/optional/(?P<optional_num>\d+)/$',
                            views.lesson_view, name='lesson_optional'),

--- a/curricula/views.py
+++ b/curricula/views.py
@@ -195,6 +195,13 @@ def chapter_view(request, slug, unit_slug, chapter_num):
                   {'curriculum': curriculum, 'unit': unit, 'chapter': chapter, 'pdf': pdf})
 
 
+@api_view(['GET', ])
+def lesson_export(request, slug, unit_slug, lesson_num):
+    lesson = get_object_or_404(Lesson, unit__slug=unit_slug, unit__curriculum__slug=slug, number=lesson_num)
+    serializer = LessonExportSerializer(lesson)
+    return Response(serializer.data)
+
+
 # @login_required
 def lesson_view(request, slug, unit_slug, lesson_num, optional_num=False):
     pdf = request.GET.get('pdf', False)


### PR DESCRIPTION
## Background

the existing process for importing cb content into code studio requires a unit to exist on CB which is tagged with the code studio unit name. when importing CB data for the 2021 curriculum, this served as a safeguard to help make sure we always imported the correct CB unit into the corresponding code studio unit.

in order to import hoc lesson plans into code studio, we need to be a bit more flexible. code studio units like studio.code.org/s/dance do not have a corresponding units on CB. rather, HOC scripts each contain individual lessons which have lesson plans on CB at urls like https://curriculum.code.org/hoc/plugged/8/ . the full mapping of HOC scripts to CB lessons is here: https://docs.google.com/spreadsheets/d/1inzBUu4tlPh82JDiBIMCKVHacaMI-Hutex2e9inOJ4E/edit#gid=0

## Description

Adds a new path to curriculum builder to export a single lesson. the implementation is mostly copied from the views for `unit_export` and `lesson_view`.

## Testing

verified locally that this works for at least one plugged and one unplugged lesson plan:

![Screen Shot 2021-09-15 at 1 55 55 PM](https://user-images.githubusercontent.com/8001765/133508375-7dae3948-6c23-418e-be3b-2a5c2f564a76.png)

![Screen Shot 2021-09-15 at 1 57 09 PM](https://user-images.githubusercontent.com/8001765/133508502-49dd27fc-80c8-4dd6-aae7-a9e55b55708c.png)
