### PR TITLE
Fixing divide-by-zero error in publish_i18n

### DIFF
--- a/i18n/management/commands/publish_i18n.py
+++ b/i18n/management/commands/publish_i18n.py
@@ -143,5 +143,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         log("I18n Sync Step 4 of 4: Publish translated content to S3")
+        num_languages = len(self.get_language_codes_with_changes())
+        if num_languages == 0:
+            log("Publishing will be skipped because no translation updates were found.")
+            return
+
         self.publish_models()
         self.report_final_times()


### PR DESCRIPTION
# Description
We only publish changes for a language if there have been changes downloaded. There is some logging code which divide by the number of languages with changes. If no languages have changed, then the logging code ends up dividing by 0. The fix is to skip the whole I18n publish step if we don't have any changes since it won't be publishing anything.

You can see the line where the divide-by-zero happens [here](https://github.com/code-dot-org/curriculumbuilder/blob/5422d02973ece252a43a03931acc808494919ae0/i18n/management/commands/publish_i18n.py#L129). The stacktrace for the exception can be seen below.

## Links
- [JIRA](https://codedotorg.atlassian.net/browse/FND-1735)

## Testing story
* Setting up test environment now, will verify the fix before merging.

## Stacktrace
Here is the error logged in the #curriculumbuilder slack channel
```Traceback:
File "manage.py" in <module>
 16.         execute_from_command_line(sys.argv)
File "/app/.heroku/python/lib/python2.7/site-packages/django/core/management/__init__.py" in execute_from_command_line
 338.     utility.execute()
File "/app/.heroku/python/lib/python2.7/site-packages/django/core/management/__init__.py" in execute
 330.             self.fetch_command(subcommand).run_from_argv(self.argv)
File "/app/.heroku/python/lib/python2.7/site-packages/django/core/management/base.py" in run_from_argv
 390.             self.execute(*args, **cmd_options)
File "/app/.heroku/python/lib/python2.7/site-packages/django/core/management/base.py" in execute
 441.             output = self.handle(*args, **options)
File "/app/i18n/management/commands/publish_i18n.py" in handle
 147.         self.report_final_times()
File "/app/i18n/management/commands/publish_i18n.py" in report_final_times
 129.             datetime.timedelta(seconds=int(self.total_elapsed_time/num_languages)),
Exception Type: ZeroDivisionError
Exception Value: float division by zero

```
# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
