### PR TITLE
Link to commonsense.org from the common sense education logo

### DIFF
--- a/curricula/templates/curricula/partials/lesson_front.html
+++ b/curricula/templates/curricula/partials/lesson_front.html
@@ -31,7 +31,7 @@
         the Common Sense Education logo above the overview
         {% endcomment %}
         {% if lesson.creative_commons_image == lesson.CREATIVE_COMMONS_BY_NC_ND_IMAGE %}
-            <a href="https://creativecommons.org/">
+            <a href="https://commonsense.org/">
                 <img src="{% static "img/common_sense_education.png" %}" style="padding: 10px 0;">
             </a> 
         {% endif %}


### PR DESCRIPTION
The link on the common sense education logo in the lesson plans pointed to creativecommons.org instead of commonsense.org. See https://codedotorg.slack.com/archives/C02EEGWLHR8/p1634833217006000

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
