### PR TITLE
Remove introduced in section from maps and blocks

### DIFF
--- a/documentation/templates/documentation/partials/block.html
+++ b/documentation/templates/documentation/partials/block.html
@@ -1,10 +1,6 @@
 {% load mezzanine_tags %}
 {% load staticfiles %}
 
-{% if embed == None %}
-
-{% endif %}
-
 {% if code_block.image %}
     <img src="{{ code_block.image.url }}" class="block_svg" />
 {% else %}


### PR DESCRIPTION
We have had an "Introduced In" section on block pages in Code Documentation which would tell you the most recent course that block is used in. However since our courses for 21-22 are not on CurriculumBuilder anymore it points to the wrong year and it is confusing students. We will be rebuilding these features in Code Studio soon so for now we are just going to remove this section to get rid of the confusion.

### Before
<img width="1045" alt="Screen Shot 2021-10-26 at 12 13 40 PM" src="https://user-images.githubusercontent.com/208083/138919114-5e2caedc-f3bc-459c-9ee0-116a752b7b91.png">

### After

<img width="1085" alt="Screen Shot 2021-10-26 at 12 12 48 PM" src="https://user-images.githubusercontent.com/208083/138919056-88a4a9a7-0292-4a82-ac73-41c812b3a014.png">

## Links

- [Jira](https://codedotorg.atlassian.net/browse/PLAT-1402)
- 
## Testing story

- Manual Local Testing