### PR TITLE
add endpoint for json formatted concept maps

### DIFF
--- a/documentation/serializers.py
+++ b/documentation/serializers.py
@@ -1,0 +1,17 @@
+import json
+from rest_framework import serializers
+from documentation.models import Map
+
+class MapExportSerializer(serializers.ModelSerializer):
+    category = serializers.SerializerMethodField()
+    children = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Map
+        fields = ('title', 'content', 'slug', 'category', 'children')
+
+    def get_category(self, obj):
+        return obj.get_absolute_url()
+
+    def get_children(self, obj):
+        return obj.get_children().map(lambda map: map.name)

--- a/documentation/serializers.py
+++ b/documentation/serializers.py
@@ -3,15 +3,11 @@ from rest_framework import serializers
 from documentation.models import Map
 
 class MapExportSerializer(serializers.ModelSerializer):
-    category = serializers.SerializerMethodField()
     children = serializers.SerializerMethodField()
 
     class Meta:
         model = Map
-        fields = ('title', 'content', 'slug', 'category', 'children')
-
-    def get_category(self, obj):
-        return obj.get_absolute_url()
+        fields = ('title', 'content', 'slug', 'children')
 
     def get_children(self, obj):
-        return obj.get_children().map(lambda map: map.name)
+        return map(lambda x: x.slug, obj.get_children())

--- a/documentation/urls.py
+++ b/documentation/urls.py
@@ -6,11 +6,16 @@ from documentation import views
 urlpatterns = [
     multiurl(
         url(r'^$', views.index, name='index'),
+        
+        # Export this map for import into code studio
+        url(r'^export/(?P<slug>.*).json$', views.map_export, name="map_export"),
+
         url(r'^(?P<slug>.*)/$', views.map_view, name="map_view"),
 
         # Assumes that all IDEs with docs end in lab to avoid routing conflicts with curriculum routes
         url(r'^(?P<slug>[-\w]+lab)/$', views.ide_view, name='ide_view'),
         url(r'^(?P<ide_slug>[-\w]+lab)/(?P<slug>[-\w.]+)/$', views.block_view, name='block_view'),
         url(r'^(?P<ide_slug>[-\w]+lab)/(?P<slug>[-\w.]+)/embed/$', views.embed_view, name='embed_view'),
+        
     )
 ]

--- a/documentation/views.py
+++ b/documentation/views.py
@@ -2,10 +2,13 @@ from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseNotFound, HttpResponseServerError
 
 from multiurl import ContinueResolving
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
 from mezzanine.pages.models import Page
 
 from models import IDE, Block, Map
+from serializers import *
 
 
 def index(request):
@@ -88,3 +91,9 @@ def maps_view(request, ):
     maps = Map.objects.filter(parent__slug='concepts')
     page = Page.objects.get(slug='concepts')
     return render(request, 'documentation/pages.html', {'page': page, 'pages': maps, 'type': 'Maps'})
+
+@api_view(['GET', ])
+def map_export(request, slug):
+    page = get_object_or_404(Map, slug=slug)
+    serializer = MapExportSerializer(page)
+    return Response(serializer.data)


### PR DESCRIPTION
# Description

Adds a new endpoint to expose the concept maps as formatted json. Provides the list of children, too, to make it easier to recursively discover all concept maps from the import side.

modelled after these previous PRs:
https://github.com/code-dot-org/curriculumbuilder/pull/318
https://github.com/code-dot-org/curriculumbuilder/pull/319

sample data:
![image](https://user-images.githubusercontent.com/82416901/150236380-9e698b7c-6aeb-4691-b4e2-400378adbf7b.png)
![image](https://user-images.githubusercontent.com/82416901/150236427-a0f604fb-b6aa-49dd-8e45-93048bb63e46.png)
