### PR TITLE
Concept maps export order field

### DIFF
--- a/documentation/serializers.py
+++ b/documentation/serializers.py
@@ -4,13 +4,17 @@ from documentation.models import Block, Example, Map, Parameter
 
 class MapExportSerializer(serializers.ModelSerializer):
     children = serializers.SerializerMethodField()
+    order = serializers.SerializerMethodField()
 
     class Meta:
         model = Map
-        fields = ('title', 'content', 'slug', 'children')
+        fields = ('title', 'content', 'slug', 'order', 'children')
 
     def get_children(self, obj):
         return map(lambda x: x.slug, obj.get_children())
+        
+    def get_order(self, obj):
+        return obj._order
 
 class ParameterExportSerializer(serializers.ModelSerializer):
     class Meta:

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,13 +49,13 @@ docutils
 factory-boy==2.12.0
 filebrowser-safe==0.4.1
 future==0.15.2
--e git://github.com/mrjoshida/django-csvimport.git@master#egg=django_csvimport
--e git://github.com/mrjoshida/grappelli-nested-inlines.git@master#egg=grappelli_nested_inlines
--e git://github.com/mrjoshida/PyPDF2.git@master#egg=PyPDF2
-# -e git://github.com/mrjoshida/django-extensions.git@master#egg=django_extensions
-# -e git://github.com/mrjoshida/django-codemirror-widget.git@master#egg=django_codemirror_widget
--e git://github.com/mrjoshida/django-jackfrost.git@master#egg=django-jackfrost
--e git://github.com/mrjoshida/django_cloneable.git@master#egg=django_cloneable
+-e git+https://github.com/mrjoshida/django-csvimport.git@master#egg=django_csvimport
+-e git+https://github.com/mrjoshida/grappelli-nested-inlines.git@master#egg=grappelli_nested_inlines
+-e git+https://github.com/mrjoshida/PyPDF2.git@master#egg=PyPDF2
+# -e git+https://github.com/mrjoshida/django-extensions.git@master#egg=django_extensions
+# -e git+https://github.com/mrjoshida/django-codemirror-widget.git@master#egg=django_codemirror_widget
+-e git+https://github.com/mrjoshida/django-jackfrost.git@master#egg=django-jackfrost
+-e git+https://github.com/mrjoshida/django_cloneable.git@master#egg=django_cloneable
 grappelli-safe==0.4.2
 gunicorn==19.6.0
 html5lib==0.999999
@@ -63,7 +63,7 @@ html5lib==0.999999
 ipython
 jsonfield==1.0.3
 # Markdown==2.6.2
--e git://github.com/mrjoshida/Python-Markdown.git@master#egg=Markdown
+-e git+https://github.com/mrjoshida/Python-Markdown.git@master#egg=Markdown
 markdown-newtab==0.1.0
 messytables==0.14.5
 mezzanine-pagedown==0.8


### PR DESCRIPTION
# Description

Adds the order field to the list of fields exported for concept maps.
Also updates the git:// requirements to be https:// to conform with github security changes: https://github.blog/2021-09-01-improving-git-protocol-security-github/


<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

Tested manually on local curriculumbuilder with import script

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
